### PR TITLE
feat: functional newsletter subscription + Resend domain update

### DIFF
--- a/app/api/forgot-password/route.js
+++ b/app/api/forgot-password/route.js
@@ -46,7 +46,7 @@ export const POST = async (req) => {
     `;
 
     const emailResponse = await resend.emails.send({
-      from: "SwiftCart <noreply@aihridoy.com>",
+      from: "SwiftCart <noreply@ashrafulislam.im>",
       to: email,
       subject: "Password Reset Request",
       html: htmlContent,

--- a/app/api/newsletter/route.js
+++ b/app/api/newsletter/route.js
@@ -1,0 +1,55 @@
+import { Resend } from "resend";
+import { dbConnect } from "@/service/mongo";
+import { Newsletter } from "@/models/newsletter-model";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export const POST = async (req) => {
+    try {
+        const { email } = await req.json();
+
+        if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            return new Response(
+                JSON.stringify({ success: false, error: "Please enter a valid email address" }),
+                { status: 400, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        await dbConnect();
+
+        const existing = await Newsletter.findOne({ email: email.toLowerCase() });
+        if (existing) {
+            return new Response(
+                JSON.stringify({ success: false, error: "This email is already subscribed" }),
+                { status: 409, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        await Newsletter.create({ email });
+
+        await resend.emails.send({
+            from: "SwiftCart <noreply@ashrafulislam.im>",
+            to: email,
+            subject: "Welcome to SwiftCart Newsletter",
+            html: `
+              <div style="font-family: Arial, sans-serif; padding: 20px; background-color: #f9f9f9;">
+                <h2 style="color: #333;">Welcome to SwiftCart!</h2>
+                <p>Thanks for subscribing. You'll now get exclusive offers, new arrivals & home decor inspiration delivered to your inbox weekly.</p>
+                <hr style="border: 0; border-top: 1px solid #ddd; margin: 20px 0;">
+                <p style="color: #777; font-size: 12px;">This email was sent from SwiftCart.</p>
+              </div>
+            `,
+        });
+
+        return new Response(
+            JSON.stringify({ success: true, message: "Subscribed successfully" }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+        );
+    } catch (error) {
+        console.error("Error in newsletter API:", error);
+        return new Response(
+            JSON.stringify({ success: false, error: "Something went wrong. Please try again." }),
+            { status: 500, headers: { "Content-Type": "application/json" } }
+        );
+    }
+};

--- a/app/api/send-email/route.js
+++ b/app/api/send-email/route.js
@@ -8,7 +8,7 @@ export const POST = async (req) => {
         const { to, subject, html } = body;
 
         const emailResponse = await resend.emails.send({
-            from: "SwiftCart <noreply@aihridoy.com>",
+            from: "SwiftCart <noreply@ashrafulislam.im>",
             to,
             subject,
             html,

--- a/components/NewsLetter.jsx
+++ b/components/NewsLetter.jsx
@@ -52,15 +52,28 @@ const NewsLetter = () => {
       return;
     }
 
-    // Simulate API call
-    setTimeout(() => {
+    try {
+      const res = await fetch("/api/newsletter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+
+      if (!res.ok || !data.success) {
+        setError(data.error || "Something went wrong. Please try again.");
+        setIsSubmitting(false);
+        return;
+      }
+
       setSuccess("🎉 Welcome aboard! You will get our regular welcome offers.");
       setEmail("");
       setIsSubmitting(false);
-
-      // Clear success message after 5 seconds
       setTimeout(() => setSuccess(""), 5000);
-    }, 1500);
+    } catch (err) {
+      setError("Something went wrong. Please try again.");
+      setIsSubmitting(false);
+    }
   };
 
   const handleInputChange = (e) => {

--- a/models/newsletter-model.js
+++ b/models/newsletter-model.js
@@ -1,0 +1,13 @@
+import mongoose, { Schema } from "mongoose";
+
+const newsletterSchema = new Schema({
+    email: {
+        type: String,
+        required: true,
+        unique: true,
+        lowercase: true,
+        trim: true,
+    },
+}, { timestamps: true });
+
+export const Newsletter = mongoose.models.newsletters ?? mongoose.model("newsletters", newsletterSchema);


### PR DESCRIPTION
## Summary
- Newsletter form now posts to real `/api/newsletter` endpoint (Mongo dedupe check + welcome email via Resend), replacing the fake setTimeout stub
- New `Newsletter` model to store subscriber emails
- Updated Resend sender domain from old `aihridoy.com` to currently verified `ashrafulislam.im` in send-email and forgot-password routes

## Test plan
- [x] POST new email -> 200 success, subscriber saved, welcome email sent
- [x] POST duplicate email -> 409 "already subscribed"
- [x] POST invalid email -> 400 validation error
- [x] Verified against live dev server + Mongo, test row cleaned up after