### PR TITLE
feat: consistent skeleton loading across the app

### DIFF
--- a/app/(main)/cart/[cartId]/page.js
+++ b/app/(main)/cart/[cartId]/page.js
@@ -9,6 +9,7 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { getCartItemById } from "@/actions/cart-utils";
 import { sendEmail } from "@/actions/contact";
+import { DetailSkeleton } from "@/components/skeletons";
 
 const Checkout = () => {
   const { cartId } = useParams();
@@ -291,22 +292,8 @@ const Checkout = () => {
   }, [session]);
 
   // Show loading while session is loading
-  if (sessionStatus === "loading") {
-    return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
-        <p className="ml-4">Loading session...</p>
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
-        <p className="ml-4">Loading checkout data...</p>
-      </div>
-    );
+  if (sessionStatus === "loading" || isLoading) {
+    return <DetailSkeleton />;
   }
 
   if (error) {

--- a/app/(main)/category/[slug]/CategoryPage.jsx
+++ b/app/(main)/category/[slug]/CategoryPage.jsx
@@ -10,6 +10,7 @@ import { addToCart, getCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import ProductCard from "@/components/ProductCard";
+import { ProductGridSkeleton } from "@/components/skeletons";
 
 const CategoryPage = ({ params, initialProducts }) => {
   const { slug } = params;
@@ -178,8 +179,11 @@ const CategoryPage = ({ params, initialProducts }) => {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
+      <div className="container py-10">
+        <h1 className="text-2xl font-semibold text-gray-800 mb-8 text-center uppercase">
+          {formattedCategoryName}
+        </h1>
+        <ProductGridSkeleton count={12} />
       </div>
     );
   }

--- a/app/(main)/edit-product/[id]/page.js
+++ b/app/(main)/edit-product/[id]/page.js
@@ -18,6 +18,7 @@ import {
   FaSave,
   FaSpinner,
 } from "react-icons/fa";
+import { FormSkeleton } from "@/components/skeletons";
 
 // Helper function to validate URLs
 const isValidImageUrl = (url) => {
@@ -207,8 +208,10 @@ export default function EditProductPage({ params }) {
   // Loading state while fetching session
   if (isLoadingSession) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-blue-500"></div>
+      <div className="min-h-screen bg-gray-50 py-8 px-4">
+        <div className="max-w-4xl mx-auto bg-white rounded-xl shadow-md p-8">
+          <FormSkeleton fields={8} />
+        </div>
       </div>
     );
   }
@@ -220,8 +223,10 @@ export default function EditProductPage({ params }) {
 
   if (isLoadingProduct || !productData) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-4 border-blue-500"></div>
+      <div className="min-h-screen bg-gray-50 py-8 px-4">
+        <div className="max-w-4xl mx-auto bg-white rounded-xl shadow-md p-8">
+          <FormSkeleton fields={8} />
+        </div>
       </div>
     );
   }

--- a/app/(main)/orders/[orderId]/page.js
+++ b/app/(main)/orders/[orderId]/page.js
@@ -10,6 +10,7 @@ import { toast } from "react-toastify";
 import Link from "next/link";
 import Image from "next/image";
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
+import { DetailSkeleton } from "@/components/skeletons";
 
 const OrderDetails = () => {
   const { orderId } = useParams();
@@ -342,11 +343,7 @@ const downloadReceipt = async (order) => {
 };
 
   if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
-      </div>
-    );
+    return <DetailSkeleton />;
   }
 
   if (error) {

--- a/app/(main)/products/Products.jsx
+++ b/app/(main)/products/Products.jsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import ProductCard from "@/components/ProductCard";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { session } from "@/actions/auth-utils";
+import { ProductGridSkeleton } from "@/components/skeletons";
 
 const Products = ({ initialProducts }) => {
   const queryClient = useQueryClient();
@@ -321,8 +322,13 @@ const Products = ({ initialProducts }) => {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
+      <div className="min-h-screen py-10 bg-white">
+        <div className="mx-auto max-w-7xl px-4">
+          <h1 className="text-2xl font-semibold text-gray-800 mb-8 text-center uppercase">
+            All Products
+          </h1>
+          <ProductGridSkeleton count={12} />
+        </div>
       </div>
     );
   }

--- a/app/(main)/products/[id]/ProductDetails.jsx
+++ b/app/(main)/products/[id]/ProductDetails.jsx
@@ -12,6 +12,7 @@ import { addReview, getReviewsByProductId } from "@/actions/review-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { FaStar, FaRegStar, FaShoppingBag } from "react-icons/fa";
+import { ProductDetailSkeleton } from "@/components/skeletons";
 import { session } from "@/actions/auth-utils";
 
 const ProductDetails = ({ params, initialProduct }) => {
@@ -366,11 +367,7 @@ const ProductDetails = ({ params, initialProduct }) => {
   };
 
   if (productLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
-      </div>
-    );
+    return <ProductDetailSkeleton />;
   }
 
   if (productError) {

--- a/app/(main)/search/SearchPage.jsx
+++ b/app/(main)/search/SearchPage.jsx
@@ -10,6 +10,7 @@ import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import ProductCard from "@/components/ProductCard";
+import { ProductGridSkeleton } from "@/components/skeletons";
 
 const SearchPage = () => {
   const queryClient = useQueryClient();
@@ -173,8 +174,8 @@ const SearchPage = () => {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-[500px]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
+      <div className="container py-10">
+        <ProductGridSkeleton count={12} />
       </div>
     );
   }

--- a/app/dashboard/products-list/page.js
+++ b/app/dashboard/products-list/page.js
@@ -11,6 +11,7 @@ import { FaSearch, FaTimes } from "react-icons/fa";
 
 import { getProducts, deleteProduct } from "@/actions/products";
 import { session } from "@/actions/auth-utils";
+import { Skeleton } from "@/components/skeletons";
 
 const ProductsPage = () => {
   const [visibleProducts, setVisibleProducts] = useState(10);
@@ -133,8 +134,20 @@ const ProductsPage = () => {
   // Loading UI
   if (isLoadingSession || isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-screen">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+      <div className="p-4 sm:p-6">
+        <Skeleton className="h-9 w-48 mb-6" />
+        <div className="divide-y divide-gray-200">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="py-6 flex flex-col md:flex-row items-center md:items-start gap-6">
+              <Skeleton className="h-40 w-40 rounded-md flex-shrink-0" />
+              <div className="flex-1 w-full space-y-3">
+                <Skeleton className="h-5 w-1/2" />
+                <Skeleton className="h-4 w-1/3" />
+                <Skeleton className="h-4 w-1/4" />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/app/user-dashboard/orders/[orderId]/page.js
+++ b/app/user-dashboard/orders/[orderId]/page.js
@@ -10,6 +10,7 @@ import { toast } from "react-toastify";
 import Link from "next/link";
 import Image from "next/image";
 import { PDFDocument, rgb, StandardFonts } from "pdf-lib";
+import { DetailSkeleton } from "@/components/skeletons";
 
 const OrderDetails = () => {
   const { orderId } = useParams();
@@ -342,11 +343,7 @@ const downloadReceipt = async (order) => {
 };
 
   if (isLoading) {
-    return (
-      <div className="flex justify-center items-center min-h-[100vh]">
-        <div className="animate-spin rounded-full h-20 w-20 border-b-2 border-gray-900"></div>
-      </div>
-    );
+    return <DetailSkeleton />;
   }
 
   if (error) {

--- a/app/user-dashboard/page.js
+++ b/app/user-dashboard/page.js
@@ -37,6 +37,7 @@ import {
   FiGift
 } from 'react-icons/fi';
 import Link from 'next/link';
+import { Skeleton } from '@/components/skeletons';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
 
@@ -126,10 +127,20 @@ const UserDashboard = () => {
 
   if (wishlistLoading || cartLoading || orderLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto mb-4"></div>
-          <p className="text-gray-600 text-lg">Loading your dashboard...</p>
+      <div className="min-h-screen bg-gradient-to-br from-gray-50 via-white to-gray-100 p-6">
+        <Skeleton className="h-8 w-64 mb-8" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="bg-white rounded-xl shadow p-6 space-y-3">
+              <Skeleton className="h-10 w-10 rounded-full" />
+              <Skeleton className="h-6 w-16" />
+              <Skeleton className="h-4 w-24" />
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Skeleton className="h-72 w-full rounded-xl" />
+          <Skeleton className="h-72 w-full rounded-xl" />
         </div>
       </div>
     );

--- a/components/RelatedProducts.jsx
+++ b/components/RelatedProducts.jsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import Link from "next/link";
 import React, { useState } from "react";
 import { FaEye, FaHeart, FaRegHeart, FaStar, FaRegStar } from "react-icons/fa";
+import { ProductGridSkeleton } from "@/components/skeletons";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { toast } from "react-toastify";
@@ -253,33 +254,7 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
       </h2>
 
       {/* Loading State */}
-      {relatedLoading && (
-        <div className="text-center text-gray-600">
-          <p>Loading related products...</p>
-          <div className="flex justify-center mt-4">
-            <svg
-              className="animate-spin h-8 w-8 text-primary"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              ></circle>
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              ></path>
-            </svg>
-          </div>
-        </div>
-      )}
+      {relatedLoading && <ProductGridSkeleton count={4} />}
 
       {/* Error State */}
       {relatedError && !relatedLoading && (

--- a/components/skeletons.jsx
+++ b/components/skeletons.jsx
@@ -1,0 +1,59 @@
+export const Skeleton = ({ className = "" }) => (
+  <div className={`animate-pulse rounded bg-gray-200 ${className}`} />
+);
+
+export const ProductCardSkeleton = () => (
+  <div className="bg-white rounded-xl shadow-md p-4">
+    <Skeleton className="w-full h-48 rounded-lg mb-4" />
+    <Skeleton className="h-5 w-3/4 mb-2" />
+    <Skeleton className="h-4 w-1/2 mb-2" />
+    <Skeleton className="h-4 w-1/3 mb-4" />
+    <Skeleton className="h-10 w-full rounded-lg" />
+  </div>
+);
+
+export const ProductGridSkeleton = ({ count = 8 }) => (
+  <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+    {Array.from({ length: count }).map((_, i) => (
+      <ProductCardSkeleton key={i} />
+    ))}
+  </div>
+);
+
+export const ProductDetailSkeleton = () => (
+  <div className="container grid grid-cols-1 md:grid-cols-2 gap-6 py-5">
+    <Skeleton className="w-full h-96 rounded-xl" />
+    <div className="space-y-4">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-8 w-3/4" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-4/6" />
+      <Skeleton className="h-10 w-32" />
+      <div className="flex gap-4 pt-4">
+        <Skeleton className="h-12 w-32 rounded-lg" />
+        <Skeleton className="h-12 w-28 rounded-lg" />
+      </div>
+    </div>
+  </div>
+);
+
+export const FormSkeleton = ({ fields = 6 }) => (
+  <div className="space-y-6">
+    {Array.from({ length: fields }).map((_, i) => (
+      <div key={i}>
+        <Skeleton className="h-4 w-24 mb-2" />
+        <Skeleton className="h-11 w-full rounded-lg" />
+      </div>
+    ))}
+  </div>
+);
+
+export const DetailSkeleton = () => (
+  <div className="container py-10 space-y-6">
+    <Skeleton className="h-8 w-64" />
+    <Skeleton className="h-32 w-full rounded-xl" />
+    <Skeleton className="h-32 w-full rounded-xl" />
+    <Skeleton className="h-6 w-40" />
+  </div>
+);


### PR DESCRIPTION
## Summary
Some pages (FeaturedProduct, Wishlist, NewArrival, etc.) already had proper layout-matching skeletons; others just showed a bare spinner or nothing while `isLoading`. Added a small shared skeleton library and wired it into every remaining gap:

- `components/skeletons.jsx`: `Skeleton` (base pulse primitive), `ProductCardSkeleton`, `ProductGridSkeleton`, `ProductDetailSkeleton`, `FormSkeleton`, `DetailSkeleton`
- Product grid pages: products listing, category, search, related products (on PDP)
- Product detail page
- Checkout (`cart/[cartId]`)
- Order detail (both `orders/[orderId]` and its `user-dashboard` copy)
- Edit-product form
- Admin products list (row-shaped skeleton matching its actual list layout, not a generic table)
- User dashboard overview (stat cards + chart placeholders)

Note: `app/(main)/products/Products.jsx`, `CategoryPage.jsx`, and `ProductDetails.jsx` already get `initialData` from the server (#29), so their skeleton branch is mostly a defensive fallback now rather than something you'll see on every load — added for consistency/robustness rather than as the primary fix.

Left `components/EditProduct.jsx` alone — grepped for usages and it's dead code, not rendered by any route (the real edit-product page has its own inline form logic), so no user-visible loading state to fix there.

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run` — 6/6 passing
- [x] Verified `/products`, `/search`, `/about-us` all 200 against dev server after the change