### PR TITLE
fix: PDP image gallery, hover zoom, and dead icon dots

### DIFF
--- a/app/(main)/products/[id]/ProductDetails.jsx
+++ b/app/(main)/products/[id]/ProductDetails.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useState } from "react";
-import Image from "next/image";
 import { toast } from "react-toastify";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import RelatedProducts from "@/components/RelatedProducts";
@@ -11,8 +10,18 @@ import { addToCart, getCart, updateCartQuantity } from "@/actions/cart-utils";
 import { addReview, getReviewsByProductId } from "@/actions/review-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { FaStar, FaRegStar, FaShoppingBag } from "react-icons/fa";
+import {
+  FaStar,
+  FaRegStar,
+  FaShoppingBag,
+  FaHeart,
+  FaRegHeart,
+  FaFacebookF,
+  FaTwitter,
+  FaInstagram,
+} from "react-icons/fa";
 import { ProductDetailSkeleton } from "@/components/skeletons";
+import ProductImageGallery from "@/components/ProductImageGallery";
 import { session } from "@/actions/auth-utils";
 
 const ProductDetails = ({ params, initialProduct }) => {
@@ -401,27 +410,11 @@ const ProductDetails = ({ params, initialProduct }) => {
       {/* Main Product Section */}
       <div className="container grid grid-cols-1 md:grid-cols-2 gap-6 py-5">
         {/* Product Images Section */}
-        <div>
-          <Image
-            src={product.mainImage}
-            alt={product.title}
-            width={500}
-            height={500}
-            className="w-full rounded-lg shadow-md"
-          />
-          <div className="grid grid-cols-5 gap-4 mt-4">
-            {product.thumbnails.map((thumbnail, index) => (
-              <Image
-                key={index}
-                src={thumbnail}
-                alt={`Thumbnail ${index + 1}`}
-                width={100}
-                height={100}
-                className="w-full cursor-pointer border rounded-lg shadow-sm hover:shadow-md transition"
-              />
-            ))}
-          </div>
-        </div>
+        <ProductImageGallery
+          mainImage={product.mainImage}
+          thumbnails={product.thumbnails}
+          title={product.title}
+        />
 
         {/* Product Information Section */}
         <div>
@@ -555,20 +548,22 @@ const ProductDetails = ({ params, initialProduct }) => {
                     d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                   ></path>
                 </svg>
+              ) : isInWishlist ? (
+                <FaHeart className="text-red-500" />
               ) : (
-                <i className={`fa-heart ${isInWishlist ? "fa-solid text-red-500" : "fa-regular"}`}></i>
+                <FaRegHeart />
               )}
               {isInWishlist ? "Remove from Wishlist" : "Add to Wishlist"}
             </button>
           </div>
           <div className="flex gap-3 mt-4">
-            {["facebook-f", "twitter", "instagram"].map((icon, index) => (
+            {[FaFacebookF, FaTwitter, FaInstagram].map((Icon, index) => (
               <a
                 key={index}
                 href="#"
                 className="text-gray-400 hover:text-gray-500 h-8 w-8 rounded-full border border-gray-300 flex items-center justify-center"
               >
-                <i className={`fa-brands fa-${icon}`}></i>
+                <Icon size={14} />
               </a>
             ))}
           </div>

--- a/components/ProductImageGallery.jsx
+++ b/components/ProductImageGallery.jsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+const ProductImageGallery = ({ mainImage, thumbnails = [], title }) => {
+  const images = [mainImage, ...thumbnails.filter((t) => t !== mainImage)];
+  const [selectedImage, setSelectedImage] = useState(mainImage);
+  const [isZooming, setIsZooming] = useState(false);
+  const [zoomPos, setZoomPos] = useState({ x: 50, y: 50 });
+
+  const handleMouseMove = (e) => {
+    const { left, top, width, height } = e.currentTarget.getBoundingClientRect();
+    const x = ((e.clientX - left) / width) * 100;
+    const y = ((e.clientY - top) / height) * 100;
+    setZoomPos({ x, y });
+  };
+
+  return (
+    <div>
+      <div
+        className="relative aspect-square w-full overflow-hidden rounded-lg shadow-md cursor-zoom-in bg-gray-50"
+        onMouseMove={handleMouseMove}
+        onMouseEnter={() => setIsZooming(true)}
+        onMouseLeave={() => setIsZooming(false)}
+      >
+        <Image
+          src={selectedImage}
+          alt={title}
+          fill
+          priority
+          className="object-cover"
+        />
+        {isZooming && (
+          <div
+            className="pointer-events-none absolute inset-0 hidden md:block"
+            style={{
+              backgroundImage: `url(${selectedImage})`,
+              backgroundSize: "200%",
+              backgroundPosition: `${zoomPos.x}% ${zoomPos.y}%`,
+              backgroundRepeat: "no-repeat",
+            }}
+          />
+        )}
+      </div>
+
+      {images.length > 1 && (
+        <div className="grid grid-cols-5 gap-4 mt-4">
+          {images.map((image, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => setSelectedImage(image)}
+              aria-label={`View image ${index + 1}`}
+              aria-current={selectedImage === image ? "true" : undefined}
+              className={`relative aspect-square w-full overflow-hidden rounded-lg border-2 shadow-sm transition hover:shadow-md ${
+                selectedImage === image ? "border-primary" : "border-transparent"
+              }`}
+            >
+              <Image
+                src={image}
+                alt={`${title} thumbnail ${index + 1}`}
+                fill
+                className="object-cover"
+              />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProductImageGallery;


### PR DESCRIPTION
## Summary
Three PDP issues reported from screenshots:
1. Main product image sometimes took up huge vertical space (portrait source images rendered at full natural height, no cap)
2. Thumbnail images weren't clickable
3. No zoom on the product image
4. Three unstyled white/empty circles under Add to Cart

Root cause of #4 (and part of the ask): those circles are social-share icons rendered as raw Font Awesome `<i className="fa-brands fa-...">` tags — leftover from removing the dead `/node_modules` FA stylesheet link in an earlier PR (#28). No CSS means no glyph, just an empty bordered circle. Same problem on the wishlist heart icon on this page, which I missed in that earlier cleanup pass (its grep pattern didn't match Font Awesome 6's `fa-brands`/`fa-regular` syntax).

Fixes:
- New `components/ProductImageGallery.jsx`: fixed `aspect-square` + `object-cover` box so image height is always consistent regardless of source aspect ratio; thumbnails are now buttons that swap the main image (highlighted when active); hover magnifier zoom (mousemove-tracked 200% background-position overlay, desktop only, no new dependency)
- Wishlist heart icon and the 3 social icons replaced with `react-icons/fa` equivalents (already used everywhere else in the app)

Zoom UX (hover magnifier vs click-to-lightbox) was a genuine design fork — confirmed with the user: hover magnifier only.

## Test plan
- [x] `npm run build` passes clean
- [x] `npx vitest run` — 6/6 passing
- [x] Verified via curl against dev server: zero raw Font Awesome classes remain on the PDP, gallery `aspect-square`/`cursor-zoom-in` markup present, icons render as real `<svg>` elements