### PR TITLE
fix: remove hardcoded debug:true in auth config

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -93,5 +93,4 @@ export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
       return token;
     },
   },
-  debug: true,
 });


### PR DESCRIPTION
## Summary
`auth.js` had `debug: true` hardcoded, forcing Auth.js debug logging on regardless of environment — spammed the terminal with `[auth][warn][debug-enabled]` on every single request (POST /, session checks, etc). Auth.js defaults debug off already; removed the override.

Separately: the `TypeError: __webpack_require__.C is not a function` / "Failed to generate static paths for /products/[id]" seen in the same logs is not a code issue — confirmed `page.js` hasn't changed in the last 2 merged PRs, and the actual request around that error still returned 200. It's a known Next.js 14 dev-mode symptom from a stale webpack module registry after repeated hot-reloads/branch switches in one dev session. Fix is a clean `.next` + dev server restart on the affected machine, not a source change.

## Test plan
- [x] `node --check auth.js` — syntax valid
- [x] One-line removal of a boolean config key, no logic change; skipped a full `npm run build` per standing rule about not touching `.next`/build while a dev server may be running