### PR TITLE
chore: add Playwright MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds `.mcp.json` with the Playwright MCP server so Claude Code can drive a real browser in this project for visual review/testing instead of curl-only checks.