### PR TITLE
fix: consistent, correctly-implemented search debouncing

### DIFF
--- a/app/dashboard/orders/page.js
+++ b/app/dashboard/orders/page.js
@@ -21,6 +21,7 @@ import {
   FaSearch
 } from "react-icons/fa";
 import { session } from "@/actions/auth-utils";
+import { useDebounce } from "@/hooks/useDebounce";
 
 // Skeleton Loader Component
 const SkeletonRow = () => (
@@ -57,6 +58,7 @@ const OrderList = () => {
   const queryClient = useQueryClient();
   const [currentPage, setCurrentPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 400);
   const limit = 10;
   
   useEffect(() => {
@@ -125,9 +127,9 @@ const OrderList = () => {
   };
 
   // Filter orders based on search term
-  const filteredOrders = orders.filter(order => 
-    order._id.toLowerCase().includes(searchTerm.toLowerCase()) || 
-    (order.user?.name && order.user.name.toLowerCase().includes(searchTerm.toLowerCase()))
+  const filteredOrders = orders.filter(order =>
+    order._id.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ||
+    (order.user?.name && order.user.name.toLowerCase().includes(debouncedSearchTerm.toLowerCase()))
   );
 
   // Pagination controls

--- a/app/dashboard/products-list/page.js
+++ b/app/dashboard/products-list/page.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Image from "next/image";
 import Link from "next/link";
@@ -12,6 +12,7 @@ import { FaSearch, FaTimes } from "react-icons/fa";
 import { getProducts, deleteProduct } from "@/actions/products";
 import { session } from "@/actions/auth-utils";
 import { Skeleton } from "@/components/skeletons";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const ProductsPage = () => {
   const [visibleProducts, setVisibleProducts] = useState(10);
@@ -20,27 +21,10 @@ const ProductsPage = () => {
   
   // Search state
   const [searchTerm, setSearchTerm] = useState("");
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
-  
+  const debouncedSearchTerm = useDebounce(searchTerm, 800);
+
   const queryClient = useQueryClient();
   const router = useRouter();
-
-  // Debounce function
-  const debounce = useCallback((func, delay) => {
-    let timer;
-    return (...args) => {
-      clearTimeout(timer);
-      timer = setTimeout(() => func(...args), delay);
-    };
-  }, []);
-
-  // Debounce search term
-  useEffect(() => {
-    const debouncedSetSearchTerm = debounce((value) => {
-      setDebouncedSearchTerm(value);
-    }, 800);
-    debouncedSetSearchTerm(searchTerm);
-  }, [searchTerm, debounce]);
 
   if(user && user?.user?.role !== "admin") {
     router.push('/');

--- a/app/dashboard/users/page.js
+++ b/app/dashboard/users/page.js
@@ -23,6 +23,7 @@ import {
   FaInfoCircle
 } from "react-icons/fa";
 import { session } from "@/actions/auth-utils";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const SkeletonRow = () => (
   <tr className="animate-pulse">
@@ -65,6 +66,7 @@ const UserList = () => {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 400);
   const [roleFilter, setRoleFilter] = useState("all");
   const limit = 10;
   
@@ -109,9 +111,9 @@ const UserList = () => {
 
   // Filter users based on search term and role filter
   const filteredUsers = users.filter(user => {
-    const matchesSearch = 
-      user.name.toLowerCase().includes(searchTerm.toLowerCase()) || 
-      user.email.toLowerCase().includes(searchTerm.toLowerCase());
+    const matchesSearch =
+      user.name.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ||
+      user.email.toLowerCase().includes(debouncedSearchTerm.toLowerCase());
     
     const matchesRole = roleFilter === "all" || user.role === roleFilter;
     

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { FaSearch, FaHeart, FaShoppingBag, FaUser, FaBox, FaBars, FaTimes } from "react-icons/fa";
@@ -12,6 +12,7 @@ import { getOrders } from "@/actions/order-utils";
 import { searchProducts } from "@/actions/products";
 import { useRouter } from "next/navigation";
 import { session } from "@/actions/auth-utils";
+import { useDebounce } from "@/hooks/useDebounce";
 
 const Header = () => {
   const queryClient = useQueryClient();
@@ -22,17 +23,8 @@ const Header = () => {
 
   // Search state
   const [searchTerm, setSearchTerm] = useState("");
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-
-  // Debounce search term
-  const debounce = useCallback((func, delay) => {
-    let timer;
-    return (...args) => {
-      clearTimeout(timer);
-      timer = setTimeout(() => func(...args), delay);
-    };
-  }, []);
 
   useEffect(() => {
     const fetchUserSession = async () => {
@@ -48,12 +40,8 @@ const Header = () => {
   }, []);
 
   useEffect(() => {
-    const debouncedSetSearchTerm = debounce((value) => {
-      setDebouncedSearchTerm(value);
-      setIsDropdownOpen(value.length > 0);
-    }, 500);
-    debouncedSetSearchTerm(searchTerm);
-  }, [searchTerm, debounce]);
+    setIsDropdownOpen(debouncedSearchTerm.length > 0);
+  }, [debouncedSearchTerm]);
 
   // Scroll effect
   useEffect(() => {

--- a/hooks/useDebounce.js
+++ b/hooks/useDebounce.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce(value, delay = 500) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
Audited every search input in the codebase (grepped for search state/handlers across app + components). Found 4:

1. **Header** (product search dropdown, hits `/api/products/search` via `searchProducts`)
2. **dashboard/products-list** (client-side filter)
3. **dashboard/orders** (client-side filter) — no debounce at all
4. **dashboard/users** (client-side filter) — no debounce at all

Header and products-list already had a "debounce," but both shared the same bug: the debounced closure was rebuilt inside a `useEffect` on every render instead of properly cancelling the previous pending timeout via cleanup. Net effect: typing fast fired one delayed update per keystroke instead of coalescing into a single update after typing stops — for Header specifically, that meant one network request per keystroke, defeating the point of debouncing.

Added `hooks/useDebounce.js` (standard `setTimeout` + cleanup-based debounce) and wired it into all four:
- Header: 500ms (unchanged delay, now actually correct — matters most here since it drives a network request)
- products-list: 800ms (unchanged delay)
- orders/users: 400ms, newly added (client-side filtering, lower stakes but still avoids re-filtering on every keystroke)

`(main)/search/SearchPage.jsx` was checked too — it has no live-typing input of its own (reads `q` from the URL, set by Header's submit), so nothing to debounce there.

## Test plan
- [x] `npx eslint` on all 5 touched files — clean, no errors/warnings
- [x] `npx vitest run` — 6/6 passing
- [x] Traced every remaining `searchTerm` reference in touched files to confirm inputs still bind to the immediate value (for responsive typing) while filtering/queries use the debounced value