### PR TITLE
fix: correct vertical centering of loading spinner on shop pages

### DIFF
--- a/app/(shop)/layout.js
+++ b/app/(shop)/layout.js
@@ -8,11 +8,13 @@ import CopyRight from "@/components/CopyRight";
 export default function ShopLayout({ children }) {
   return (
     <ClientLayout>
-      <Header />
-      <Navbar />
-      {children}
-      <Footer />
-      <CopyRight />
+      <div className="flex min-h-screen flex-col">
+        <Header />
+        <Navbar />
+        <main className="flex flex-1 flex-col">{children}</main>
+        <Footer />
+        <CopyRight />
+      </div>
     </ClientLayout>
   );
 }

--- a/app/(shop)/loading.js
+++ b/app/(shop)/loading.js
@@ -1,5 +1,5 @@
 import RouteLoader from "@/components/RouteLoader";
 
 export default function Loading() {
-  return <RouteLoader />;
+  return <RouteLoader fill />;
 }

--- a/components/RouteLoader.jsx
+++ b/components/RouteLoader.jsx
@@ -1,8 +1,12 @@
 "use client";
 
-const RouteLoader = () => {
+const RouteLoader = ({ fill = false }) => {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-8">
+    <div
+      className={`flex flex-col items-center justify-center gap-8 ${
+        fill ? "flex-1" : "min-h-screen"
+      }`}
+    >
       <div className="relative h-28 w-28">
         <div className="absolute inset-0 rounded-full bg-red-500/20 blur-2xl animate-pulse" />
         <div className="absolute inset-0 rounded-full border-[6px] border-gray-200" />


### PR DESCRIPTION
## Summary
Reported: spinner position is correct on the homepage, but on pages with Header/Navbar the vertical centering is off — sits below true screen center.

Cause: \`RouteLoader\` forces its own \`min-h-screen\` block. On \`(shop)\` pages that block renders *after* Header/Navbar in the content slot, so its 100vh centers itself starting partway down the page rather than against the actual viewport.

Fix, no magic pixel numbers (header height isn't fixed - it shrinks on scroll):
- \`(shop)/layout.js\`: wrapped in a flex column (\`min-h-screen\`), content slot is now a \`flex-1 <main>\` that naturally absorbs whatever space is left below header/nav, regardless of their real height
- \`RouteLoader\` takes a \`fill\` prop: when set, uses \`flex-1\` to stretch within that \`<main>\` and centers inside it, instead of forcing its own viewport height
- \`(shop)/loading.js\` passes \`fill\`; root/ungrouped \`loading.js\` (no chrome present) keeps the old standalone \`min-h-screen\` behavior unchanged

## Test plan
- [x] \`npx eslint\` on all 4 touched files — clean
- [x] Reasoned through flexbox mechanics: outer \`min-h-screen flex-col\` + \`flex-1 main\` + \`flex-1\` RouteLoader means the spinner centers within exactly (viewport height − header/nav/footer/copyright natural heights), self-adjusting with no hardcoded offsets