### PR TITLE
fix: give loading spinner breathing room in fill mode

### DIFF
--- a/components/RouteLoader.jsx
+++ b/components/RouteLoader.jsx
@@ -4,7 +4,7 @@ const RouteLoader = ({ fill = false }) => {
   return (
     <div
       className={`flex flex-col items-center justify-center gap-8 ${
-        fill ? "flex-1" : "min-h-screen"
+        fill ? "flex-1 min-h-[50vh] py-20" : "min-h-screen"
       }`}
     >
       <div className="relative h-28 w-28">


### PR DESCRIPTION
## Summary
Reported: after the previous centering fix, the spinner looked cramped — jammed right against the navbar above and footer below.

\`flex-1\` alone let it collapse to whatever leftover space happened to exist (short, since the footer content on that page is tall). Added \`min-h-[50vh]\` as a floor and \`py-20\` padding so it always has room, while \`flex-1\` still lets it grow to fill more when the page is taller/footer shorter. Centering (\`items-center justify-center\`) unaffected either way.

## Test plan
- [x] \`npx eslint components/RouteLoader.jsx\` — clean