### PR TITLE
perf: cache Mongo connection, speed up dev compile, reduce refetch churn

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    optimizePackageImports: ["react-icons"],
+  },
   images: {
     remotePatterns: [
       {
@@ -16,12 +19,6 @@ const nextConfig = {
       },
     ],
   },
-//   experimental: {
-//     staleTimes: {
-//       dynamic: 0,
-//       static: 0,
-//     },
-//   },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/providers/ReactQueryProvider.js
+++ b/providers/ReactQueryProvider.js
@@ -3,7 +3,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30 * 1000,
+    },
+  },
+});
 
 export default function ReactQueryProvider({ children }) {
   return (

--- a/service/mongo.js
+++ b/service/mongo.js
@@ -1,10 +1,28 @@
 import mongoose from "mongoose";
 
+const MONGODB_URI = process.env.MONGODB_CONNECTION_STRING;
+
+let cached = global._mongoose;
+if (!cached) {
+    cached = global._mongoose = { conn: null, promise: null };
+}
+
 export async function dbConnect() {
-    try {
-        const conn = await mongoose.connect(String(process.env.MONGODB_CONNECTION_STRING));
-        return conn;
-    } catch (err) {
-        console.error(err);
+    if (cached.conn) {
+        return cached.conn;
     }
+
+    if (!cached.promise) {
+        cached.promise = mongoose.connect(String(MONGODB_URI)).then((m) => m);
+    }
+
+    try {
+        cached.conn = await cached.promise;
+    } catch (err) {
+        cached.promise = null;
+        console.error(err);
+        throw err;
+    }
+
+    return cached.conn;
 }


### PR DESCRIPTION
## Summary
User reported pages taking too long to load and asked to optimize compile time too. Four concrete fixes, in order of impact:

1. **\`service/mongo.js\`**: \`dbConnect()\` called \`mongoose.connect()\` fresh on every single request with zero caching — a well-documented Next.js+Mongoose gotcha, worse in dev since HMR re-evaluates modules and can pile up connections. Cached the connection promise on \`global\` (the standard fix). Also now throws on failure instead of silently swallowing it — every caller already wraps \`dbConnect()\` in its own try/catch, so this makes failures visible instead of masked.
2. **\`next.config.mjs\`**: added \`experimental.optimizePackageImports: ["react-icons"]\` so Next generates per-icon modules in dev instead of compiling whole icon-set barrel files (react-icons is imported broadly across the app). Also removed a stale commented-out \`experimental\` block left over from earlier.
3. **\`providers/ReactQueryProvider.js\`**: \`QueryClient\` had no default \`staleTime\` (defaults to 0), so every remount/navigation re-fetched wishlist/cart/products even if fetched a second ago. Set a 30s default — cuts redundant network waterfalls on normal browsing without meaningfully hurting freshness (window-focus refetch still on).
4. **\`package.json\`**: \`dev\` script now runs \`next dev --turbo\`. This is the direct answer to "optimize compiling" — confirmed with the user first given compat risk (styled-jsx is used in a couple components), verified working on an isolated port before committing.

## Test plan
- [x] \`npx eslint\` on all touched JS files — clean
- [x] Verified live on an isolated dev instance (port 3003, untouched user's own port 3000 server): Turbopack starts clean ("Ready in 1728ms"), \`/\` and \`/products\` both return 200
- [x] Timed cold vs warm compile: \`/products\` cold ~6s vs the ~17-19s measured earlier this session with webpack; warm hits ~0.7s, unchanged
- [x] Verified \`/api/products\` returns real product data (confirms the Mongo connection caching change didn't break the connection)
- [x] \`npx vitest run\` — 6/6 passing