### PR TITLE
fix: give newsletter section a background band

### DIFF
--- a/components/NewsLetter.jsx
+++ b/components/NewsLetter.jsx
@@ -109,117 +109,119 @@ const NewsLetter = () => {
   };
 
   return (
-    <section id="newsletter-section" className="container py-16 bg-white">
-      <div
-        className={`mx-auto max-w-2xl text-center transition-all duration-1000 ${
-          isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"
-        }`}
-      >
-        <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary mb-4">
-          <FaEnvelope />
-          Join 50,000+ Happy Subscribers
-        </div>
-
-        <h2 className="text-2xl sm:text-3xl font-semibold text-gray-800 uppercase mb-3">
-          Never Miss a Great Deal
-        </h2>
-
-        <p className="text-gray-600 mb-8">
-          Get exclusive offers, new arrivals & home decor inspiration
-          delivered to your inbox weekly
-        </p>
-
-        <form
-          onSubmit={handleSubmit}
-          className="mb-10"
-          aria-label="Newsletter subscription form"
+    <section id="newsletter-section" className="bg-primary/5 py-16">
+      <div className="container">
+        <div
+          className={`mx-auto max-w-2xl text-center transition-all duration-1000 ${
+            isVisible ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"
+          }`}
         >
-          <div className="mx-auto max-w-md sm:max-w-lg">
-            <div className="flex">
-              <input
-                type="email"
-                required
-                value={email}
-                onChange={handleInputChange}
-                placeholder="Enter your email address"
-                className={`flex-1 min-w-0 rounded-l-md border border-r-0 px-4 py-3 text-sm sm:text-base focus:outline-none ${
-                  error ? "border-red-400" : "border-primary"
-                }`}
-                aria-label="Email address"
-                aria-invalid={error ? "true" : "false"}
-                aria-describedby={
-                  error ? "email-error" : success ? "email-success" : undefined
-                }
-              />
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="flex items-center gap-2 rounded-r-md border border-primary bg-primary px-6 sm:px-8 font-medium uppercase text-white transition hover:bg-transparent hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
-                aria-label="Subscribe to newsletter"
-              >
-                {isSubmitting ? (
-                  <>
-                    <FaSpinner className="animate-spin" />
-                    <span className="hidden sm:inline">Joining...</span>
-                  </>
-                ) : (
-                  <>
-                    <span>Subscribe</span>
-                    <FaArrowRight className="hidden sm:inline" />
-                  </>
-                )}
-              </button>
-            </div>
-
-            {error && (
-              <div
-                id="email-error"
-                className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-700"
-              >
-                {error}
-              </div>
-            )}
-
-            {success && (
-              <div
-                id="email-success"
-                className="mt-3 rounded-md border border-green-200 bg-green-50 p-3 text-sm font-medium text-green-700"
-              >
-                {success}
-              </div>
-            )}
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary mb-4">
+            <FaEnvelope />
+            Join 50,000+ Happy Subscribers
           </div>
-        </form>
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-10 mx-auto max-w-xl">
-          {BENEFITS.map(({ icon: Icon, title, description }) => (
-            <div key={title} className="flex flex-col items-center text-center">
-              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-                <Icon className="h-5 w-5" />
-              </div>
-              <h3 className="font-semibold text-gray-800 mb-1">{title}</h3>
-              <p className="text-sm text-gray-500">{description}</p>
-            </div>
-          ))}
-        </div>
+          <h2 className="text-2xl sm:text-3xl font-semibold text-gray-800 uppercase mb-3">
+            Never Miss a Great Deal
+          </h2>
 
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm text-gray-500">
-          <div className="flex items-center gap-2">
-            <FaLock className="text-primary" />
-            <span>100% Privacy Protected</span>
-          </div>
-          <div className="hidden sm:block h-1 w-1 rounded-full bg-gray-300" />
-          <div className="flex items-center gap-2">
-            <FaCheckCircle className="text-primary" />
-            <span>No Spam, Ever</span>
-          </div>
-          <div className="hidden sm:block h-1 w-1 rounded-full bg-gray-300" />
-          <Link
-            href="/unsubscribe"
-            className="underline hover:text-primary transition-colors"
+          <p className="text-gray-600 mb-8">
+            Get exclusive offers, new arrivals & home decor inspiration
+            delivered to your inbox weekly
+          </p>
+
+          <form
+            onSubmit={handleSubmit}
+            className="mb-10"
+            aria-label="Newsletter subscription form"
           >
-            Unsubscribe anytime
-          </Link>
+            <div className="mx-auto max-w-md sm:max-w-lg">
+              <div className="flex">
+                <input
+                  type="email"
+                  required
+                  value={email}
+                  onChange={handleInputChange}
+                  placeholder="Enter your email address"
+                  className={`flex-1 min-w-0 rounded-l-md border border-r-0 px-4 py-3 text-sm sm:text-base focus:outline-none ${
+                    error ? "border-red-400" : "border-primary"
+                  }`}
+                  aria-label="Email address"
+                  aria-invalid={error ? "true" : "false"}
+                  aria-describedby={
+                    error ? "email-error" : success ? "email-success" : undefined
+                  }
+                />
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="flex items-center gap-2 rounded-r-md border border-primary bg-primary px-6 sm:px-8 font-medium uppercase text-white transition hover:bg-transparent hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                  aria-label="Subscribe to newsletter"
+                >
+                  {isSubmitting ? (
+                    <>
+                      <FaSpinner className="animate-spin" />
+                      <span className="hidden sm:inline">Joining...</span>
+                    </>
+                  ) : (
+                    <>
+                      <span>Subscribe</span>
+                      <FaArrowRight className="hidden sm:inline" />
+                    </>
+                  )}
+                </button>
+              </div>
+
+              {error && (
+                <div
+                  id="email-error"
+                  className="mt-3 rounded-md border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-700"
+                >
+                  {error}
+                </div>
+              )}
+
+              {success && (
+                <div
+                  id="email-success"
+                  className="mt-3 rounded-md border border-green-200 bg-green-50 p-3 text-sm font-medium text-green-700"
+                >
+                  {success}
+                </div>
+              )}
+            </div>
+          </form>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-10 mx-auto max-w-xl">
+            {BENEFITS.map(({ icon: Icon, title, description }) => (
+              <div key={title} className="flex flex-col items-center text-center">
+                <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+                  <Icon className="h-5 w-5" />
+                </div>
+                <h3 className="font-semibold text-gray-800 mb-1">{title}</h3>
+                <p className="text-sm text-gray-500">{description}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-sm text-gray-500">
+            <div className="flex items-center gap-2">
+              <FaLock className="text-primary" />
+              <span>100% Privacy Protected</span>
+            </div>
+            <div className="hidden sm:block h-1 w-1 rounded-full bg-gray-300" />
+            <div className="flex items-center gap-2">
+              <FaCheckCircle className="text-primary" />
+              <span>No Spam, Ever</span>
+            </div>
+            <div className="hidden sm:block h-1 w-1 rounded-full bg-gray-300" />
+            <Link
+              href="/unsubscribe"
+              className="underline hover:text-primary transition-colors"
+            >
+              Unsubscribe anytime
+            </Link>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Follow-up to #44. Reported: the restyled section matched the app's UI but looked "too off" — flat white on an all-white page, no visual separation from the sections around it.

The previous version had \`bg-white\` on the already width-constrained \`container\` div, so even choosing a color there would've painted a boxed rectangle, not a proper edge-to-edge section band. Restructured: background now lives on the outer \`<section>\` (full-bleed, soft primary tint \`bg-primary/5\`), with \`container\` nested inside purely for content width/padding — the correct structure for a colored section band, matching how the original (over-styled) version was structured before the #44 rewrite.

## Test plan
- [x] \`npx eslint components/NewsLetter.jsx\` — clean
- [x] Verified live on an isolated port (3005): homepage 200, \`bg-primary/5\` present in the rendered HTML, no errors