### PR TITLE
fix: audit and fix customer flow bugs across wishlist, cart, checkout, reviews

### DIFF
--- a/actions/cart-utils/index.js
+++ b/actions/cart-utils/index.js
@@ -15,7 +15,7 @@ export const addToCart = async (productId, quantity = 1) => {
     });
     return result.data;
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.response?.data?.error || error.message);
   }
 };
 
@@ -31,7 +31,7 @@ export const getCart = async () => {
     });
     return result.data; 
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.response?.data?.error || error.message);
   }
 };
 
@@ -48,7 +48,7 @@ export const removeFromCart = async (productId) => {
     });
     return result.data;
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.response?.data?.error || error.message);
   }
 };
 
@@ -71,7 +71,7 @@ export const updateCartQuantity = async (productId, quantity) => {
     );
     return result.data;
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.response?.data?.error || error.message);
   }
 };
 
@@ -91,6 +91,6 @@ export const getCartItemById = async (cartId) => {
     });
     return result.data;
   } catch (error) {
-    throw new Error(error.message);
+    throw new Error(error.response?.data?.error || error.message);
   }
 };

--- a/actions/register/index.js
+++ b/actions/register/index.js
@@ -8,7 +8,7 @@ export const registerUser = async (userData) => {
     console.error("Error registering user:", error);
     return {
       success: false,
-      message: error.message || "An unexpected error occurred",
+      message: error.response?.data?.error || error.message || "An unexpected error occurred",
     };
   }
 };

--- a/actions/review-utils/index.js
+++ b/actions/review-utils/index.js
@@ -16,7 +16,7 @@ export async function addReview({ productId, review, rating }) {
     });
     return response.data;
   } catch (error) {
-    throw new Error(error || "Failed to add review");
+    throw new Error(error.response?.data?.error || error.message || "Failed to add review");
   }
 }
 
@@ -32,6 +32,6 @@ export async function getReviewsByProductId(productId) {
     });
     return response.data.reviews;
   } catch (error) {
-    throw new Error(error || "Failed to fetch reviews");
+    throw new Error(error.response?.data?.error || error.message || "Failed to fetch reviews");
   }
 }

--- a/actions/wishlist/index.js
+++ b/actions/wishlist/index.js
@@ -32,6 +32,6 @@ export const updateWishlist = async (productId, action) => {
     );
     return response.data;
   } catch (error) {
-    throw new Error(error || "Failed to update wishlist");
+    throw new Error(error.response?.data?.error || error.message || "Failed to update wishlist");
   }
 };

--- a/app/(shop)/cart/[cartId]/page.js
+++ b/app/(shop)/cart/[cartId]/page.js
@@ -104,7 +104,7 @@ const Checkout = () => {
         <table style="width: 100%; border-collapse: collapse;">
           <thead>
             <tr style="background-color: #e6f0fa;">
-              <th style="border: 1px solid #ddd; padding: 8px;">Product ID</th>
+              <th style="border: 1px solid #ddd; padding: 8px;">Product</th>
               <th style="border: 1px solid #ddd; padding: 8px;">Quantity</th>
               <th style="border: 1px solid #ddd; padding: 8px;">Total</th>
             </tr>
@@ -114,7 +114,7 @@ const Checkout = () => {
               ?.map(
                 (item) => `
                   <tr>
-                    <td style="border: 1px solid #ddd; padding: 8px;">${item?.product}</td>
+                    <td style="border: 1px solid #ddd; padding: 8px;">${item?.product?.title || "Product"}</td>
                     <td style="border: 1px solid #ddd; padding: 8px;">${item?.quantity}</td>
                     <td style="border: 1px solid #ddd; padding: 8px;">$${(item?.price * item?.quantity).toFixed(2)}</td>
                   </tr>

--- a/app/(shop)/cart/page.js
+++ b/app/(shop)/cart/page.js
@@ -142,7 +142,7 @@ const CartPage = () => {
       }, 3000);
       return;
     }
-    if (removeMutation.isLoading) return;
+    if (removeMutation.isPending) return;
     removeMutation.mutate(productId);
   };
 
@@ -171,7 +171,7 @@ const CartPage = () => {
       return;
     }
 
-    if (updateQuantityMutation.isLoading) return;
+    if (updateQuantityMutation.isPending) return;
     updateQuantityMutation.mutate({ productId, quantity: newQuantity });
   };
 
@@ -191,7 +191,7 @@ const CartPage = () => {
 
     const newQuantity = currentQuantity > 1 ? currentQuantity - 1 : 1;
     if (newQuantity === currentQuantity) return;
-    if (updateQuantityMutation.isLoading) return;
+    if (updateQuantityMutation.isPending) return;
     updateQuantityMutation.mutate({ productId, quantity: newQuantity });
   };
 
@@ -368,7 +368,7 @@ const CartPage = () => {
                               }
                               disabled={
                                 item.quantity === 1 ||
-                                (updateQuantityMutation.isLoading &&
+                                (updateQuantityMutation.isPending &&
                                   updateQuantityMutation.variables?.productId === item.product._id)
                               }
                               className={`w-8 h-8 flex items-center justify-center rounded-full transition-all duration-300 ${
@@ -383,7 +383,7 @@ const CartPage = () => {
                               <FaMinus />
                             </button>
                             <div className="w-12 text-center py-2 bg-white border border-gray-200 rounded-lg">
-                              {updateQuantityMutation.isLoading &&
+                              {updateQuantityMutation.isPending &&
                               updateQuantityMutation.variables?.productId === item.product._id ? (
                                 <FaSpinner className="animate-spin mx-auto" />
                               ) : (
@@ -395,19 +395,19 @@ const CartPage = () => {
                                 handleIncreaseQuantity(
                                   item.product._id,
                                   item.quantity,
-                                  item.product.inStock,
+                                  item.product.quantity,
                                   e
                                 )
                               }
                               disabled={
-                                (item.product.inStock !== undefined &&
-                                  item.quantity >= item.product.inStock) ||
-                                (updateQuantityMutation.isLoading &&
+                                (item.product.quantity !== undefined &&
+                                  item.quantity >= item.product.quantity) ||
+                                (updateQuantityMutation.isPending &&
                                   updateQuantityMutation.variables?.productId === item.product._id)
                               }
                               className={`w-8 h-8 flex items-center justify-center rounded-full transition-all duration-300 ${
-                                (item.product.inStock !== undefined &&
-                                  item.quantity >= item.product.inStock) ||
+                                (item.product.quantity !== undefined &&
+                                  item.quantity >= item.product.quantity) ||
                                 (updateQuantityMutation.isPending &&
                                   updateQuantityMutation.variables?.productId === item.product._id)
                                   ? "bg-gray-200 text-gray-400 cursor-not-allowed"
@@ -421,11 +421,11 @@ const CartPage = () => {
                           <button
                             onClick={(e) => handleRemoveFromCart(item.product._id, e)}
                             disabled={
-                              removeMutation.isLoading &&
+                              removeMutation.isPending &&
                               removeMutation.variables === item.product._id
                             }
                             className={`p-2 rounded-full transition-all duration-300 ${
-                              removeMutation.isLoading &&
+                              removeMutation.isPending &&
                               removeMutation.variables === item.product._id
                                 ? "bg-gray-200 text-gray-400 cursor-not-allowed"
                                 : "bg-red-100 text-red-600 hover:bg-red-200 hover:shadow-md"

--- a/app/(shop)/category/[slug]/CategoryPage.jsx
+++ b/app/(shop)/category/[slug]/CategoryPage.jsx
@@ -147,7 +147,7 @@ const CategoryPage = ({ params, initialProducts }) => {
       setTimeout(() => router.push("/login"), 3000);
       return;
     }
-    if (wishlistLoading || wishlistMutation.isLoading) return;
+    if (wishlistLoading || wishlistMutation.isPending) return;
     const action = wishlistData?.wishlist?.some((item) => item._id === productId) ? "remove" : "add";
     wishlistMutation.mutate({ productId, action });
   };
@@ -167,7 +167,7 @@ const CategoryPage = ({ params, initialProducts }) => {
     if (isInCart(productId)) {
       router.push("/cart");
     } else {
-      if (cartMutation.isLoading) return;
+      if (cartMutation.isPending) return;
       cartMutation.mutate({ productId, quantity: 1 });
     }
   };

--- a/app/(shop)/products/Products.jsx
+++ b/app/(shop)/products/Products.jsx
@@ -212,7 +212,7 @@ const Products = ({ initialProducts }) => {
 
     // Apply in-stock filter
     if (filters.inStock) {
-      result = result.filter((product) => product.inStock !== false);
+      result = result.filter((product) => product.availability === "In Stock");
     }
 
     // Apply sorting
@@ -261,7 +261,7 @@ const Products = ({ initialProducts }) => {
     if (isInCart(productId)) {
       router.push("/cart");
     } else {
-      if (cartMutation.isLoading) return;
+      if (cartMutation.isPending) return;
       cartMutation.mutate({ productId, quantity: 1 });
     }
   };

--- a/app/(shop)/products/[id]/ProductDetails.jsx
+++ b/app/(shop)/products/[id]/ProductDetails.jsx
@@ -274,7 +274,7 @@ const ProductDetails = ({ params, initialProduct }) => {
       return;
     }
 
-    const maxQuantity = product.inStock !== undefined ? product.inStock : 10;
+    const maxQuantity = product.quantity !== undefined ? product.quantity : 10;
     if (quantity > maxQuantity) {
       toast.warn(`Cannot add more than ${maxQuantity} items.`, {
         position: "top-right",
@@ -304,7 +304,9 @@ const ProductDetails = ({ params, initialProduct }) => {
       return;
     }
 
-    if (!reviewText || rating < 1) {
+    const trimmedReview = reviewText.trim();
+
+    if (!trimmedReview || rating < 1) {
       toast.warn("Please provide a review and rating.", {
         position: "top-right",
         autoClose: 3000,
@@ -312,8 +314,16 @@ const ProductDetails = ({ params, initialProduct }) => {
       return;
     }
 
+    if (trimmedReview.length < 3 || trimmedReview.length > 500) {
+      toast.warn("Review must be between 3 and 500 characters.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      return;
+    }
+
     if (reviewMutation.isPending) return;
-    reviewMutation.mutate({ productId: id, review: reviewText, rating });
+    reviewMutation.mutate({ productId: id, review: trimmedReview, rating });
   };
 
   // Handle star rating click
@@ -345,7 +355,7 @@ const ProductDetails = ({ params, initialProduct }) => {
       return;
     }
 
-    const maxQuantity = product.inStock !== undefined ? product.inStock : 10;
+    const maxQuantity = product.quantity !== undefined ? product.quantity : 10;
     const newQuantity = quantity + 1;
 
     if (newQuantity > maxQuantity) {
@@ -403,7 +413,7 @@ const ProductDetails = ({ params, initialProduct }) => {
     ? Number((reviews.reduce((sum, review) => sum + review.rating, 0) / totalReviews).toFixed(1))
     : 0;
 
-  const maxQuantity = product.inStock !== undefined ? product.inStock : 10;
+  const maxQuantity = product.quantity !== undefined ? product.quantity : 10;
 
   return (
     <>
@@ -495,7 +505,7 @@ const ProductDetails = ({ params, initialProduct }) => {
               }
               className={`border px-8 py-2 font-medium rounded uppercase flex items-center gap-2 transition ${
                 cartMutation.isPending ||
-                updateCartQuantityMutation.isLoading ||
+                updateCartQuantityMutation.isPending ||
                 cartLoading ||
                 product.availability !== "In Stock"
                   ? "bg-primary opacity-50 cursor-not-allowed"
@@ -626,7 +636,7 @@ const ProductDetails = ({ params, initialProduct }) => {
                 type="submit"
                 disabled={reviewMutation.isPending}
                 className={`bg-primary text-white px-6 py-2 rounded-lg font-medium hover:bg-primary-dark transition ${
-                  reviewMutation.isLoading ? "opacity-50 cursor-not-allowed" : ""
+                  reviewMutation.isPending ? "opacity-50 cursor-not-allowed" : ""
                 }`}
               >
                 {reviewMutation.isPending ? (

--- a/app/(shop)/wishlist/page.js
+++ b/app/(shop)/wishlist/page.js
@@ -270,7 +270,8 @@ const Wishlist = () => {
   // Pagination logic
   const totalItems = wishlist.length;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
+  const validCurrentPage = Math.min(Math.max(1, currentPage), totalPages || 1);
+  const startIndex = (validCurrentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const paginatedWishlist = wishlist.slice(startIndex, endIndex);
 
@@ -453,10 +454,10 @@ const Wishlist = () => {
               <div className="flex justify-center mt-8">
                 <nav className="flex items-center gap-2">
                   <button
-                    onClick={() => handlePageChange(currentPage - 1)}
-                    disabled={currentPage === 1}
+                    onClick={() => handlePageChange(validCurrentPage - 1)}
+                    disabled={validCurrentPage === 1}
                     className={`px-4 py-2 rounded-lg font-semibold flex items-center space-x-2 ${
-                      currentPage === 1
+                      validCurrentPage === 1
                         ? "bg-gray-200 text-gray-500 cursor-not-allowed"
                         : "bg-blue-600 text-white hover:bg-blue-700"
                     } transition-all duration-300 shadow-md`}
@@ -472,21 +473,21 @@ const Wishlist = () => {
                       key={page}
                       onClick={() => handlePageChange(page)}
                       className={`px-4 py-2 rounded-lg font-semibold ${
-                        currentPage === page
+                        validCurrentPage === page
                           ? "bg-blue-600 text-white shadow-lg"
                           : "bg-gray-100 text-gray-700 hover:bg-gray-200"
                       } transition-all duration-300`}
                       aria-label={`Page ${page}`}
-                      aria-current={currentPage === page ? "page" : undefined}
+                      aria-current={validCurrentPage === page ? "page" : undefined}
                     >
                       {page}
                     </button>
                   ))}
                   <button
-                    onClick={() => handlePageChange(currentPage + 1)}
-                    disabled={currentPage === totalPages}
+                    onClick={() => handlePageChange(validCurrentPage + 1)}
+                    disabled={validCurrentPage === totalPages}
                     className={`px-4 py-2 rounded-lg font-semibold flex items-center space-x-2 ${
-                      currentPage === totalPages
+                      validCurrentPage === totalPages
                         ? "bg-gray-200 text-gray-500 cursor-not-allowed"
                         : "bg-blue-600 text-white hover:bg-blue-700"
                     } transition-all duration-300 shadow-md`}

--- a/app/api/cart/route.js
+++ b/app/api/cart/route.js
@@ -22,6 +22,10 @@ export async function POST(request) {
       return NextResponse.json({ error: "Product not found" }, { status: 404 });
     }
 
+    if (product.availability !== "In Stock") {
+      return NextResponse.json({ error: "Product is out of stock" }, { status: 400 });
+    }
+
     // Find or create cart for the user
     let cart = await Cart.findOne({ user: userSession.user.id });
     if (!cart) {
@@ -33,9 +37,20 @@ export async function POST(request) {
       (item) => item.product.toString() === productId
     );
 
+    const existingQuantity = itemIndex > -1 ? cart.items[itemIndex].quantity : 0;
+    const newQuantity = existingQuantity + quantity;
+
+    if (newQuantity > product.quantity) {
+      return NextResponse.json(
+        { error: `Only ${product.quantity} left in stock` },
+        { status: 400 }
+      );
+    }
+
     if (itemIndex > -1) {
       // Update quantity if product exists
-      cart.items[itemIndex].quantity += quantity;
+      cart.items[itemIndex].quantity = newQuantity;
+      cart.items[itemIndex].price = product.price;
     } else {
       // Add new product to cart
       cart.items.push({
@@ -158,8 +173,21 @@ export async function PUT(request) {
       );
     }
 
+    const product = await Product.findById(productId);
+    if (!product) {
+      return NextResponse.json({ error: "Product not found" }, { status: 404 });
+    }
+
+    if (quantity > product.quantity) {
+      return NextResponse.json(
+        { error: `Only ${product.quantity} left in stock` },
+        { status: 400 }
+      );
+    }
+
     // Update the quantity
     cart.items[itemIndex].quantity = quantity;
+    cart.items[itemIndex].price = product.price;
 
     await cart.save();
 

--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -3,6 +3,7 @@ import { session } from "@/actions/auth-utils";
 import { dbConnect } from "@/service/mongo";
 import { Order } from "@/models/order-model";
 import { Cart } from "@/models/cart-model";
+import { Product } from "@/models/product-model";
 
 export async function POST(request) {
   try {
@@ -12,36 +13,80 @@ export async function POST(request) {
     }
 
     const body = await request.json();
-    const { cartId, shippingDetails, subtotal, shipping, total } = body;
+    const { cartId, shippingDetails, paymentDetails } = body;
 
-    if (!cartId || !shippingDetails || !subtotal || !total) {
+    if (!cartId || !shippingDetails || !paymentDetails) {
       return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
     }
 
     await dbConnect();
 
     // Find the cart to get the items
-    const cart = await Cart.findById(cartId);
+    const cart = await Cart.findById(cartId).populate("items.product");
     if (!cart || cart.user.toString() !== userSession.user.id) {
       return NextResponse.json({ error: "Cart not found" }, { status: 404 });
     }
 
+    if (cart.items.length === 0) {
+      return NextResponse.json({ error: "Cart is empty" }, { status: 400 });
+    }
+
+    // Verify stock is still available for every item - never trust client-submitted totals
+    for (const item of cart.items) {
+      if (
+        !item.product ||
+        item.product.availability !== "In Stock" ||
+        item.quantity > item.product.quantity
+      ) {
+        return NextResponse.json(
+          {
+            error: `${item.product?.title || "An item"} in your cart is no longer available in that quantity`,
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Recompute pricing server-side from the cart's own stored prices
+    const subtotal = cart.items.reduce(
+      (sum, item) => sum + item.price * item.quantity,
+      0
+    );
+    const shipping = 0;
+    const total = subtotal + shipping;
+
     // Create the order
     const order = new Order({
       user: userSession.user.id,
-      items: cart.items, // Copy items from the cart
+      items: cart.items.map((item) => ({
+        product: item.product._id,
+        quantity: item.quantity,
+        price: item.price,
+      })),
       shippingDetails,
+      paymentDetails,
       subtotal,
-      shipping: shipping || 0,
+      shipping,
       total,
       status: "Pending",
     });
 
     await order.save();
 
+    // Decrement stock for each purchased item
+    for (const item of cart.items) {
+      const remaining = Math.max(item.product.quantity - item.quantity, 0);
+      await Product.findByIdAndUpdate(item.product._id, {
+        quantity: remaining,
+        availability: remaining <= 0 ? "Out of Stock" : "In Stock",
+      });
+    }
+
     // Clear the cart by removing all items
     cart.items = [];
     await cart.save();
+
+    await order.populate("items.product");
 
     return NextResponse.json({ message: "Order placed successfully", order }, { status: 201 });
   } catch (error) {

--- a/app/dashboard/add-product/page.js
+++ b/app/dashboard/add-product/page.js
@@ -516,7 +516,7 @@ export default function AddProduct() {
               <button
                 type="submit"
                 className="bg-gradient-to-r from-indigo-600 to-purple-600 text-white font-medium px-6 py-2 sm:px-8 sm:py-3 rounded-lg shadow-md hover:shadow-lg transition-all hover:from-indigo-700 hover:to-purple-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 w-full sm:w-auto"
-                disabled={mutation.isLoading}
+                disabled={mutation.isPending}
               >
                 {mutation.isPending ? (
                   <span className="flex items-center justify-center">

--- a/app/dashboard/orders/page.js
+++ b/app/dashboard/orders/page.js
@@ -393,7 +393,7 @@ const OrderList = () => {
                               ? "bg-green-100 text-green-800"
                               : "bg-red-100 text-red-800"
                           }`}
-                          disabled={mutation.isLoading}
+                          disabled={mutation.isPending}
                         >
                           <option value="Pending">Pending</option>
                           <option value="Processing">Processing</option>

--- a/app/user-dashboard/cart/page.js
+++ b/app/user-dashboard/cart/page.js
@@ -124,7 +124,7 @@ const UserCart = () => {
       }, 3000);
       return;
     }
-    if (removeMutation.isLoading) return;
+    if (removeMutation.isPending) return;
     removeMutation.mutate(productId);
   };
 
@@ -158,7 +158,7 @@ const UserCart = () => {
       return;
     }
 
-    if (updateQuantityMutation.isLoading) return;
+    if (updateQuantityMutation.isPending) return;
     updateQuantityMutation.mutate({ productId, quantity: newQuantity });
   };
 
@@ -178,7 +178,7 @@ const UserCart = () => {
 
     const newQuantity = currentQuantity > 1 ? currentQuantity - 1 : 1;
     if (newQuantity === currentQuantity) return;
-    if (updateQuantityMutation.isLoading) return;
+    if (updateQuantityMutation.isPending) return;
     updateQuantityMutation.mutate({ productId, quantity: newQuantity });
   };
 
@@ -415,7 +415,7 @@ const UserCart = () => {
                           }
                           disabled={
                             item.quantity <= 1 ||
-                            updateQuantityMutation.isLoading
+                            updateQuantityMutation.isPending
                           }
                           className="p-2 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
@@ -433,7 +433,7 @@ const UserCart = () => {
                               e
                             )
                           }
-                          disabled={updateQuantityMutation.isLoading}
+                          disabled={updateQuantityMutation.isPending}
                           className="p-2 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
                           <BsPlus className="w-3 h-3" />
@@ -454,7 +454,7 @@ const UserCart = () => {
                     {/* Remove Button */}
                     <button
                       onClick={(e) => handleRemoveFromCart(item.product._id, e)}
-                      disabled={removeMutation.isLoading}
+                      disabled={removeMutation.isPending}
                       className="p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
                       title="Remove from cart"
                     >
@@ -477,7 +477,7 @@ const UserCart = () => {
                           }
                           disabled={
                             item.quantity <= 1 ||
-                            updateQuantityMutation.isLoading
+                            updateQuantityMutation.isPending
                           }
                           className="p-1 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
@@ -495,7 +495,7 @@ const UserCart = () => {
                               e
                             )
                           }
-                          disabled={updateQuantityMutation.isLoading}
+                          disabled={updateQuantityMutation.isPending}
                           className="p-1 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         >
                           <BsPlus className="w-3 h-3" />
@@ -523,7 +523,7 @@ const UserCart = () => {
                         onClick={(e) =>
                           handleRemoveFromCart(item.product._id, e)
                         }
-                        disabled={removeMutation.isLoading}
+                        disabled={removeMutation.isPending}
                         className="p-2 text-red-500 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50"
                         title="Remove from cart"
                       >

--- a/components/FeaturedProduct.jsx
+++ b/components/FeaturedProduct.jsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import { session } from "@/actions/auth-utils";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
+import { getReviewsByProductId } from "@/actions/review-utils";
 
 const FeaturedSkeleton = () => (
   <section className="container py-14">
@@ -76,6 +77,22 @@ const FeaturedProduct = () => {
         (b.isFeatured ? 1 : 0) - (a.isFeatured ? 1 : 0) ||
         (b.popularityScore || 0) - (a.popularityScore || 0)
     )?.[0] || null;
+
+  // Reviews for the featured product, computed live like every other product card
+  const { data: reviewsData } = useQuery({
+    queryKey: ["reviews", product?._id],
+    queryFn: () => getReviewsByProductId(product._id),
+    enabled: !!product?._id,
+  });
+
+  const reviews = reviewsData || [];
+  const totalReviews = reviews.length;
+  const averageRating =
+    totalReviews > 0
+      ? Number(
+          (reviews.reduce((sum, r) => sum + r.rating, 0) / totalReviews).toFixed(1)
+        )
+      : 0;
 
   // Wishlist data
   const {
@@ -318,32 +335,28 @@ const FeaturedProduct = () => {
             {product.description}
           </p>
 
-          {product.rating && (
-            <div className="flex items-center gap-2">
-              <div className="flex items-center">
-                {[...Array(5)].map((_, i) => (
-                  <svg
-                    key={i}
-                    className={`h-5 w-5 ${
-                      i < Math.floor(product.rating) ? "text-yellow-400" : "text-gray-300"
-                    }`}
-                    fill="currentColor"
-                    viewBox="0 0 20 20"
-                  >
-                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                  </svg>
-                ))}
-              </div>
-              <span className="text-sm text-gray-500">
-                ({product.rating.toFixed(1)})
-              </span>
-              {product.reviewCount && (
-                <span className="text-sm text-gray-500">
-                  • {product.reviewCount} reviews
-                </span>
-              )}
+          <div className="flex items-center gap-2">
+            <div className="flex items-center">
+              {[...Array(5)].map((_, i) => (
+                <svg
+                  key={i}
+                  className={`h-5 w-5 ${
+                    i < Math.floor(averageRating) ? "text-yellow-400" : "text-gray-300"
+                  }`}
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+              ))}
             </div>
-          )}
+            <span className="text-sm text-gray-500">
+              ({averageRating.toFixed(1)})
+            </span>
+            <span className="text-sm text-gray-500">
+              • {totalReviews} {totalReviews === 1 ? "review" : "reviews"}
+            </span>
+          </div>
           <div className="flex items-baseline gap-4">
             <span className="text-4xl font-bold text-gray-900">
               ${product.price.toFixed(2)}

--- a/components/ProductCard.jsx
+++ b/components/ProductCard.jsx
@@ -26,6 +26,7 @@ const ProductCard = ({
 
   // Check if the product is in the cart
   const productInCart = isInCart(product._id);
+  const outOfStock = product.availability !== "In Stock";
 
   // Fetch reviews for this product
   const { data: reviewsData, error: reviewsError, isLoading: reviewsLoading } = useQuery({
@@ -161,19 +162,24 @@ const ProductCard = ({
         <button
           onClick={(e) => handleCartAction(product._id, e)}
           disabled={
+            outOfStock ||
             cartLoading ||
             (cartMutation.isPending && cartMutation.variables?.productId === product._id)
           }
           className={`mt-auto block w-full py-2 text-center text-white rounded-lg font-medium uppercase transition ${
-            cartLoading ||
-            (cartMutation.isPending && cartMutation.variables?.productId === product._id)
+            outOfStock
+              ? "bg-gray-300 cursor-not-allowed"
+              : cartLoading ||
+                (cartMutation.isPending && cartMutation.variables?.productId === product._id)
               ? "bg-red-400 cursor-not-allowed"
               : productInCart
               ? "bg-blue-500 hover:bg-blue-600"
               : "bg-red-500 hover:bg-red-600"
           }`}
         >
-          {cartMutation.isPending && cartMutation.variables?.productId === product._id ? (
+          {outOfStock ? (
+            "Out of Stock"
+          ) : cartMutation.isPending && cartMutation.variables?.productId === product._id ? (
             <svg
               className="animate-spin h-5 w-5 text-white mx-auto"
               xmlns="http://www.w3.org/2000/svg"

--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -144,6 +144,8 @@ const ProductCard = ({ product, wishlistData, cartData, queryClient }) => {
     (item) => item._id.toString() === product._id
   );
 
+  const outOfStock = product.availability !== "In Stock";
+
   return (
     <div className="bg-white shadow-md rounded-lg overflow-hidden h-[400px] w-full flex flex-col group">
       <div className="relative w-full h-48">
@@ -249,16 +251,20 @@ const ProductCard = ({ product, wishlistData, cartData, queryClient }) => {
 
         <button
           onClick={handleCartAction}
-          disabled={cartMutation.isPending}
+          disabled={outOfStock || cartMutation.isPending}
           className={`mt-auto block w-full py-2 text-center text-white rounded-lg font-medium uppercase transition ${
-            cartMutation.isPending
+            outOfStock
+              ? "bg-gray-300 cursor-not-allowed"
+              : cartMutation.isPending
               ? "bg-red-400 cursor-not-allowed"
               : isInCart
               ? "bg-blue-500 hover:bg-blue-600"
               : "bg-red-500 hover:bg-red-600"
           }`}
         >
-          {cartMutation.isPending ? (
+          {outOfStock ? (
+            "Out of Stock"
+          ) : cartMutation.isPending ? (
             <svg
               className="animate-spin h-5 w-5 text-white mx-auto"
               xmlns="http://www.w3.org/2000/svg"

--- a/components/RelatedProducts.jsx
+++ b/components/RelatedProducts.jsx
@@ -199,7 +199,7 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
       }, 3000);
       return;
     }
-    if (wishlistLoading || wishlistMutation.isLoading) return;
+    if (wishlistLoading || wishlistMutation.isPending) return;
 
     const action = isInWishlist(productId) ? "remove" : "add";
     wishlistMutation.mutate({ productId, action });
@@ -227,7 +227,7 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
     if (isInCart(productId)) {
       router.push("/cart");
     } else {
-      if (cartMutation.isLoading) return;
+      if (cartMutation.isPending) return;
       cartMutation.mutate({ productId, quantity: 1 });
     }
   };
@@ -236,7 +236,8 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
   const products = relatedProducts?.products || [];
   const totalItems = products.length;
   const totalPages = Math.ceil(totalItems / itemsPerPage);
-  const startIndex = (currentPage - 1) * itemsPerPage;
+  const validCurrentPage = Math.min(Math.max(1, currentPage), totalPages || 1);
+  const startIndex = (validCurrentPage - 1) * itemsPerPage;
   const endIndex = startIndex + itemsPerPage;
   const paginatedProducts = products.slice(startIndex, endIndex);
 
@@ -296,19 +297,19 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
                       </Link>
                       <button
                         onClick={(e) => handleWishlistToggle(product._id, e)}
-                        disabled={wishlistLoading || (wishlistMutation.isLoading && wishlistMutation.variables?.productId === product._id)}
+                        disabled={wishlistLoading || (wishlistMutation.isPending && wishlistMutation.variables?.productId === product._id)}
                         className={`text-white text-lg w-9 h-8 rounded-full flex items-center justify-center transition ${
                           isInWishlist(product._id)
                             ? "bg-red-500 hover:bg-red-600"
                             : "bg-primary hover:bg-gray-800"
                         } ${
-                          wishlistLoading || (wishlistMutation.isLoading && wishlistMutation.variables?.productId === product._id)
+                          wishlistLoading || (wishlistMutation.isPending && wishlistMutation.variables?.productId === product._id)
                             ? "opacity-50 cursor-not-allowed"
                             : ""
                         }`}
                         title={isInWishlist(product._id) ? "Remove from Wishlist" : "Add to Wishlist"}
                       >
-                        {wishlistMutation.isLoading && wishlistMutation.variables?.productId === product._id ? (
+                        {wishlistMutation.isPending && wishlistMutation.variables?.productId === product._id ? (
                           <svg
                             className="animate-spin h-5 w-5 text-white"
                             xmlns="http://www.w3.org/2000/svg"
@@ -375,16 +376,16 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
                     {/* Add to Cart Button */}
                     <button
                       onClick={(e) => handleCartAction(product._id, e)}
-                      disabled={cartLoading || (cartMutation.isLoading && cartMutation.variables?.productId === product._id)}
+                      disabled={cartLoading || (cartMutation.isPending && cartMutation.variables?.productId === product._id)}
                       className={`mt-auto block w-full py-2 text-center text-white rounded-lg font-medium uppercase transition ${
-                        cartMutation.isLoading && cartMutation.variables?.productId === product._id
+                        cartMutation.isPending && cartMutation.variables?.productId === product._id
                           ? "bg-red-400 cursor-not-allowed"
                           : productInCart
                           ? "bg-blue-500 hover:bg-blue-600"
                           : "bg-red-500 hover:bg-red-600"
                       }`}
                     >
-                      {cartMutation.isLoading && cartMutation.variables?.productId === product._id ? (
+                      {cartMutation.isPending && cartMutation.variables?.productId === product._id ? (
                         <svg
                           className="animate-spin h-5 w-5 text-white mx-auto"
                           xmlns="http://www.w3.org/2000/svg"
@@ -423,10 +424,10 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
               <nav className="flex items-center gap-2">
                 {/* Previous Button */}
                 <button
-                  onClick={() => handlePageChange(currentPage - 1)}
-                  disabled={currentPage === 1}
+                  onClick={() => handlePageChange(validCurrentPage - 1)}
+                  disabled={validCurrentPage === 1}
                   className={`px-4 py-2 text-sm font-medium rounded ${
-                    currentPage === 1
+                    validCurrentPage === 1
                       ? "bg-gray-200 text-gray-500 cursor-not-allowed"
                       : "bg-primary text-white hover:bg-primary-dark"
                   }`}
@@ -440,10 +441,12 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
                     key={page}
                     onClick={() => handlePageChange(page)}
                     className={`px-4 py-2 text-sm font-medium rounded ${
-                      currentPage === page
+                      validCurrentPage === page
                         ? "bg-primary text-white"
                         : "bg-gray-200 text-gray-700 hover:bg-gray-300"
                     }`}
+                    aria-label={`Page ${page}`}
+                    aria-current={validCurrentPage === page ? "page" : undefined}
                   >
                     {page}
                   </button>
@@ -451,10 +454,10 @@ const RelatedProducts = ({ relatedProducts, relatedError, relatedLoading }) => {
 
                 {/* Next Button */}
                 <button
-                  onClick={() => handlePageChange(currentPage + 1)}
-                  disabled={currentPage === totalPages}
+                  onClick={() => handlePageChange(validCurrentPage + 1)}
+                  disabled={validCurrentPage === totalPages}
                   className={`px-4 py-2 text-sm font-medium rounded ${
-                    currentPage === totalPages
+                    validCurrentPage === totalPages
                       ? "bg-gray-200 text-gray-500 cursor-not-allowed"
                       : "bg-primary text-white hover:bg-primary-dark"
                   }`}

--- a/models/order-model.js
+++ b/models/order-model.js
@@ -36,6 +36,11 @@ const orderSchema = new mongoose.Schema(
       phone: { type: String, required: true },
       email: { type: String, required: true },
     },
+    paymentDetails: {
+      paymentMethod: { type: String, required: true },
+      cardLast4: { type: String, required: true },
+      cardholderName: { type: String, required: true },
+    },
     subtotal: {
       type: Number,
       required: true,


### PR DESCRIPTION
## Summary
Full audit of every customer-facing feature per request: wishlist, add-to-cart, checkout, ratings/reviews. Found and fixed 10 distinct bug classes:

1. **Broken error messages** — `actions/wishlist`, `review-utils` threw the raw Axios error object instead of extracting `.message`, showing garbage instead of real server errors like "You have already reviewed this product". `cart-utils`/`register` lost server-specific messages too. Standardized everywhere.
2. **Phantom `product.inStock` field** — schema field is actually `quantity`. Every stock-cap check silently fell back to a hardcoded `10`, and the "In Stock Only" filter checkbox was a total no-op (`undefined !== false` is always `true`).
3. **No server-side stock enforcement** — `/api/cart` POST/PUT never validated quantity against real stock; client-side caps were trivially bypassable. Added real validation + resynced cart item price to current product price (was a stale snapshot).
4. **Checkout trusted client-submitted totals** — `/api/orders` took `subtotal`/`shipping`/`total` straight from the request body, no server recalculation. A tampered request could place an order at any price. Now recomputed server-side, empty carts rejected, stock re-verified per item, stock decremented on purchase.
5. **Payment details silently discarded** — `Order` schema never defined `paymentDetails`, so Mongoose stripped it on save. The confirmation email showed "Payment Method: undefined" / "Card: \*\*\*\* undefined" on every order.
6. **Confirmation email showed raw product IDs** instead of names — order wasn't populated before building the email.
7. **No out-of-stock indication on product cards** — `ProductCard`/`ProductsCard`/`RelatedProducts` never checked `availability`, unlike the PDP and wishlist page which already did it correctly.
8. **TanStack Query v5 `isLoading`→`isPending` rename missed everywhere** — `useMutation().isLoading` doesn't exist in v5 at all. ~30 occurrences across cart pages, wishlist, product pages, and admin dashboard were checking a field that's always `undefined`: every double-submit guard was dead, every mutation spinner never showed, every "disable while submitting" state never fired.
9. **Wishlist/RelatedProducts pagination could strand you on a nonexistent page** after items shrink (e.g. removing the last item on page 2) — empty screen despite items existing on page 1. Fixed with the same clamped `validCurrentPage` pattern the cart/orders pages already used correctly.
10. **Featured Product showed a different star rating than everywhere else** — it displayed the stored `product.rating` snapshot while every other component computes the average live from actual reviews. Switched to match.

Also tightened review-form client validation (trim + 3-500 char bounds) to match what the server already enforces.

## Test plan
- [x] `npx eslint` on all 20 touched files — clean
- [x] `npx vitest run` — 6/6 passing
- [x] Verified live on an isolated port (3007, didn't touch the user's running dev server): home, products listing, PDP, wishlist, cart all return 200; confirmed `availability`/`quantity` fields present and correctly named in the real `/api/products` response