### PR TITLE
fix: dashboard layouts crash on every route with icon component props

### DIFF
--- a/app/dashboard/layout.jsx
+++ b/app/dashboard/layout.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import DashboardSidebar from "@/components/DashboardSidebar";
 import { FiPlus, FiPackage, FiUsers, FiShoppingCart, FiGrid } from "react-icons/fi";
 

--- a/app/user-dashboard/layout.jsx
+++ b/app/user-dashboard/layout.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import DashboardSidebar from "@/components/DashboardSidebar";
 import { FiGrid, FiHeart, FiShoppingCart, FiPackage, FiUser } from "react-icons/fi";
 


### PR DESCRIPTION
## Summary
Reported: navigating to /dashboard as admin crashed with "Functions cannot be passed directly to Client Components... {href: ..., icon: function FiGrid, label: ...}".

Root cause: last PR's unified sidebar has both \`app/dashboard/layout.jsx\` and \`app/user-dashboard/layout.jsx\` building a \`navItems\` array with real React icon component references (\`icon: FiGrid\`) and passing it as a prop into \`DashboardSidebar\`, which is a Client Component. Neither layout had \`"use client"\`, so they were Server Components — and functions can't be serialized across the server-to-client prop boundary. Every single route under both dashboards was broken, not just \`/dashboard\`.

Fix: both layouts do zero server-side data fetching, just static nav config and JSX composition, so marking them \`"use client"\` removes the boundary entirely with no behavior change.

## Test plan
- [x] \`npx eslint\` on both files — clean
- [x] Verified live on an isolated port (3009, didn't touch the user's running dev server): all 10 dashboard routes (5 admin, 5 customer) return 200, confirmed the error text is no longer present in the rendered HTML for \`/dashboard\`