### PR TITLE
fix: inconsistent content width across dashboard pages

### DIFF
--- a/app/dashboard/add-product/page.js
+++ b/app/dashboard/add-product/page.js
@@ -132,7 +132,7 @@ export default function AddProduct() {
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 sm:py-12 mb-16 md:mb-0">
-      <div className="max-w-full sm:max-w-6xl mx-auto px-2 sm:px-4">
+      <div className="container">
         <div className="bg-white rounded-2xl shadow-sm overflow-hidden border border-gray-100">
           <div className="flex flex-col sm:flex-row items-center justify-between bg-primary p-4 sm:p-6">
             <h1 className="text-2xl sm:text-3xl font-bold text-white mb-4 sm:mb-0">Add New Product</h1>

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -174,7 +174,7 @@ export default function DashboardPage() {
 
   if (isLoading) {
     return (
-      <div className="p-6 max-w-7xl mx-auto">
+      <div className="container py-6">
         <Skeleton className="h-8 w-64 mb-8" />
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           {Array.from({ length: 4 }).map((_, i) => (
@@ -194,7 +194,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="container py-6">
       <div className="mb-8">
         <h1 className="text-2xl font-semibold text-gray-800 uppercase">Dashboard</h1>
         <p className="text-gray-600 mt-1">

--- a/app/user-dashboard/cart/page.js
+++ b/app/user-dashboard/cart/page.js
@@ -233,7 +233,7 @@ const UserCart = () => {
   if (isLoading) {
     return (
       <div className="p-4 md:p-6 lg:p-8">
-        <div className="max-w-6xl mx-auto">
+        <div className="container">
           <div className="mb-6">
             <div className="h-8 bg-gray-200 rounded animate-pulse w-48 mb-4"></div>
             <div className="h-4 bg-gray-200 rounded animate-pulse w-32"></div>
@@ -265,7 +265,7 @@ const UserCart = () => {
   if (error) {
     return (
       <div className="p-4 md:p-6 lg:p-8">
-        <div className="max-w-6xl mx-auto">
+        <div className="container">
           <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
             <div className="text-red-600 mb-2">
               <BsCart3 className="w-12 h-12 mx-auto mb-4" />
@@ -296,7 +296,7 @@ const UserCart = () => {
 
   return (
     <div className="p-4 md:p-6 lg:p-8 mb-16 sm:mb-0 border">
-      <div className="max-w-6xl mx-auto">
+      <div className="container">
         {/* Header */}
         <div className="mb-6 md:mb-8">
           <div className="flex items-center justify-between flex-wrap gap-4">

--- a/app/user-dashboard/orders/page.js
+++ b/app/user-dashboard/orders/page.js
@@ -94,7 +94,7 @@ const OrderHistory = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gray-50 py-8 px-4">
-        <div className="max-w-6xl mx-auto space-y-4">
+        <div className="container space-y-4">
           {Array.from({ length: 3 }).map((_, index) => (
             <SkeletonOrderItem key={index} />
           ))}
@@ -108,13 +108,13 @@ const OrderHistory = () => {
     return (
       <div className="min-h-screen bg-gray-50 py-8 px-4">
         <div className="sticky top-0 z-10 bg-white/80 backdrop-blur-md shadow-md p-6 rounded-b-xl mb-6">
-          <div className="flex items-center justify-between max-w-6xl mx-auto">
+          <div className="flex items-center justify-between container">
             <h1 className="text-2xl font-bold text-gray-800">
               {userSession?.user?.role === "admin" ? "Users Order History" : "Your Order History"}
             </h1>
           </div>
         </div>
-        <div className="max-w-6xl mx-auto text-center bg-white/90 backdrop-blur-lg rounded-xl shadow-lg p-6">
+        <div className="container text-center bg-white/90 backdrop-blur-lg rounded-xl shadow-lg p-6">
           <p className="text-red-600 text-lg">Failed to load orders. Please try again later.</p>
         </div>
       </div>
@@ -137,7 +137,7 @@ const OrderHistory = () => {
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4 mb-12 sm:mb-0">
       {/* Main Content */}
-      <div className="max-w-6xl mx-auto">
+      <div className="container">
         {/* Orders Summary */}
         <div className="bg-white/90 backdrop-blur-lg rounded-xl shadow-lg p-6 mb-6 flex items-center justify-between">
           <div className="flex items-center space-x-3">

--- a/app/user-dashboard/page.js
+++ b/app/user-dashboard/page.js
@@ -84,7 +84,7 @@ const UserDashboard = () => {
 
   if (wishlistLoading || cartLoading || orderLoading) {
     return (
-      <div className="p-6 max-w-7xl mx-auto">
+      <div className="container py-6">
         <Skeleton className="h-8 w-64 mb-8" />
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           {Array.from({ length: 4 }).map((_, i) => (
@@ -159,7 +159,7 @@ const UserDashboard = () => {
     .slice(0, 5);
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="container py-6">
       <div className="mb-8">
         <h1 className="text-2xl font-semibold text-gray-800 uppercase">
           Welcome back{user?.name ? `, ${user.name}` : ""}

--- a/app/user-dashboard/profile/page.js
+++ b/app/user-dashboard/profile/page.js
@@ -119,7 +119,7 @@ export default function UserProfile() {
 
   return (
     <div className="w-full min-h-screen bg-gray-100 p-6 mb-12 sm:mb-0">
-      <div className="max-w-full mx-auto bg-white shadow-lg rounded-lg overflow-hidden">
+      <div className="container bg-white shadow-lg rounded-lg overflow-hidden">
         <div className="bg-primary p-4 sm:p-8 text-white">
           <div className="flex flex-col sm:flex-row items-center space-y-4 sm:space-y-0 sm:space-x-6">
             <div className="relative w-20 h-20 sm:w-32 sm:h-32 rounded-full overflow-hidden bg-gray-100 border-4 border-white">

--- a/app/user-dashboard/wishlist/page.js
+++ b/app/user-dashboard/wishlist/page.js
@@ -221,7 +221,7 @@ const UserWishlist = () => {
   if (isLoading || cartLoading) {
     return (
       <div className="p-4 md:p-6 lg:p-8">
-        <div className="max-w-7xl mx-auto">
+        <div className="container">
           <div className="mb-6 md:mb-8">
             <div className="flex items-center justify-between flex-wrap gap-4">
               <div>
@@ -267,7 +267,7 @@ const UserWishlist = () => {
   if (error || cartError) {
     return (
       <div className="p-4 md:p-6 lg:p-8">
-        <div className="max-w-7xl mx-auto">
+        <div className="container">
           <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
             <div className="text-red-600 mb-2">
               <AiOutlineHeart className="w-12 h-12 mx-auto mb-4" />
@@ -288,7 +288,7 @@ const UserWishlist = () => {
 
   return (
     <div className="p-4 md:p-6 lg:p-8">
-      <div className="max-w-7xl mx-auto">
+      <div className="container">
         {/* Header */}
         <div className="mb-6 md:mb-8">
           <div className="flex items-center justify-between flex-wrap gap-4">


### PR DESCRIPTION
## Summary
Reported: content column width/margins shift noticeably between dashboard pages (Overview looked narrower/more inset than Products List and Users, which stretch nearly edge to edge; Add Product used yet another width).

Cause: each page used a different max-width wrapper — \`max-w-7xl mx-auto\` (Overview, both admin and customer), \`max-w-6xl\` (Add Product, cart, orders), \`max-w-full\` (profile), or bare \`container\` (products-list, users, orders list, order detail).

Fix: standardized every dashboard page on Tailwind's \`container\` class, matching what the majority of pages already used and what the entire storefront \`(shop)\` group already uses — one consistent width behavior across the whole app.

## Test plan
- [x] \`npx eslint\` on all 7 touched files — clean
- [x] Verified live on an isolated port (3010, didn't touch the user's running dev server): all 10 dashboard routes return 200, confirmed \`container\` class actually present in the rendered HTML for both newly-fixed pages