### PR TITLE
fix: sign out doesn't navigate to login page

### DIFF
--- a/actions/auth-utils/index.js
+++ b/actions/auth-utils/index.js
@@ -21,5 +21,5 @@ export async function session() {
 }
 
 export async function doSignOut() {
-    await signOut();
+    await signOut({ redirectTo: "/login" });
   }


### PR DESCRIPTION
## Summary
Reported: clicking Sign Out from \`/dashboard\` leaves you on the same page instead of navigating to login.

\`doSignOut()\` called NextAuth's \`signOut()\` with no options. Its default behavior redirects back to the *current page's URL*, not to a dedicated page — from \`/dashboard\` that just lands you right back on \`/dashboard\`, looking like the click did nothing (even though the session was actually cleared server-side).

Fix: pass \`redirectTo: "/login"\` explicitly. \`SignOut\` is a single shared component used everywhere in the app (Navbar, dashboard sidebar), so this fixes every Sign Out button at once.

## Test plan
- [x] \`npx eslint\` — clean
- [x] Verified live on an isolated port (3011, didn't touch the user's running dev server): both \`/dashboard\` and \`/login\` compile and return 200 with no errors