### PR TITLE
fix: order detail page can't find orders past the first page

### DIFF
--- a/app/(shop)/orders/[orderId]/page.js
+++ b/app/(shop)/orders/[orderId]/page.js
@@ -21,7 +21,7 @@ const OrderDetails = () => {
   const { data, error, isLoading } = useQuery({
     queryKey: ["order", orderId],
     queryFn: async () => {
-      const result = await getOrders();
+      const result = await getOrders({ limit: 1000 });
       const order = result.orders.find((o) => o._id === orderId);
       if (!order) throw new Error("Order not found");
       return order;

--- a/app/user-dashboard/orders/[orderId]/page.js
+++ b/app/user-dashboard/orders/[orderId]/page.js
@@ -21,7 +21,7 @@ const OrderDetails = () => {
   const { data, error, isLoading } = useQuery({
     queryKey: ["order", orderId],
     queryFn: async () => {
-      const result = await getOrders();
+      const result = await getOrders({ limit: 1000 });
       const order = result.orders.find((o) => o._id === orderId);
       if (!order) throw new Error("Order not found");
       return order;


### PR DESCRIPTION
## Summary
Found while investigating a receipt-download bug report. Both order detail pages (\`(shop)/orders/[orderId]\` and \`user-dashboard/orders/[orderId]\`) fetch orders via \`getOrders()\` with no params — defaults to \`limit: 10\` — then find the target order client-side by ID. Any order beyond the user's first 10 was unfindable, throwing "Order not found" even though the order genuinely existed. Raised the limit so the lookup covers all of a user's orders.

## Test plan
- [x] \`npx eslint\` on both files — clean