### PR TITLE
fix: checkout confirmation emails silently failing to send

### DIFF
--- a/app/(shop)/cart/[cartId]/page.js
+++ b/app/(shop)/cart/[cartId]/page.js
@@ -136,26 +136,39 @@ const Checkout = () => {
         <p style="color: #0087de;">Thank you for shopping with SwiftCart!</p>
         <p style="color: #0087de;">Contact us: <a href="mailto:support@swiftcart.com">support@swiftcart.com</a></p>
       `;
-      // Send confirmation email
-      await sendEmail({
-        to: orderResponse?.order?.shippingDetails?.email,
-        subject: `SwiftCart Order Confirmation - ${orderResponse?.order?._id}`,
-        html: emailHtml,
-      });
-      return orderResponse;
+      // Send confirmation email - failure here shouldn't fail the whole
+      // order, the order is already placed at this point.
+      let emailSent = true;
+      try {
+        const emailResult = await sendEmail({
+          to: orderResponse?.order?.shippingDetails?.email,
+          subject: `SwiftCart Order Confirmation - ${orderResponse?.order?._id}`,
+          html: emailHtml,
+        });
+        emailSent = !!emailResult?.success;
+      } catch (emailError) {
+        console.error("Error sending confirmation email:", emailError);
+        emailSent = false;
+      }
+      return { ...orderResponse, emailSent };
     },
     onSuccess: (data) => {
-      toast.success("Order placed successfully and confirmation email sent!", {
-        position: "top-right",
-        autoClose: 3000,
-      });
+      toast.success(
+        data?.emailSent
+          ? "Order placed successfully and confirmation email sent!"
+          : "Order placed successfully! We couldn't send a confirmation email, but your order is confirmed.",
+        {
+          position: "top-right",
+          autoClose: 3000,
+        }
+      );
       // Redirect to an order confirmation page or homepage
       setTimeout(() => {
         router.push("/");
       }, 3000);
     },
     onError: (error) => {
-      toast.error(`Error placing order or sending email: ${error?.message}`, {
+      toast.error(`Error placing order: ${error?.message}`, {
         position: "top-right",
         autoClose: 3000,
       });

--- a/app/api/forgot-password/route.js
+++ b/app/api/forgot-password/route.js
@@ -52,6 +52,14 @@ export const POST = async (req) => {
       html: htmlContent,
     });
 
+    if (emailResponse.error) {
+      console.error("Resend rejected password reset email:", emailResponse.error);
+      return new Response(
+        JSON.stringify({ success: false, error: emailResponse.error.message }),
+        { status: 502, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
     return new Response(
       JSON.stringify({ success: true, message: "Password reset email sent" }),
       { status: 200, headers: { "Content-Type": "application/json" } }

--- a/app/api/send-email/route.js
+++ b/app/api/send-email/route.js
@@ -14,6 +14,18 @@ export const POST = async (req) => {
             html,
         });
 
+        // The Resend SDK resolves normally even when the send is rejected
+        // (unverified domain, bad recipient, rate limit, etc) - it reports
+        // the failure via `error`, it doesn't throw. Missing this check
+        // meant rejected sends were reported to the client as success.
+        if (emailResponse.error) {
+            console.error("Resend rejected email:", emailResponse.error);
+            return new Response(
+                JSON.stringify({ success: false, error: emailResponse.error.message }),
+                { status: 502, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
         return new Response(
             JSON.stringify({ success: true, emailResponse }),
             { status: 200, headers: { "Content-Type": "application/json" } }


### PR DESCRIPTION
## Summary
- `resend.emails.send()` resolves normally with `{data, error}` even when the send is rejected (unverified domain, bad recipient, rate limit) — it does not throw. Neither `/api/send-email` nor `/api/forgot-password` checked `.error`, so rejected sends were reported to the client as success. This is why customers weren't getting order confirmation emails after checkout.
- Decoupled checkout order-success from email-success in the cart page's order mutation — a failed email send no longer causes the order itself to be reported as failed (the order is already placed by that point). Toast now reflects actual email outcome.

## Test plan
- [x] `npx eslint` clean on all 3 changed files
- [x] `npx vitest run` — 6/6 passing
- [x] Live curl against `/api/send-email` with valid recipient: `{"success":true,...}` (Resend id `9bc5ca4e-3d54-45c2-9dea-029f4edfb346`)
- [x] Live curl against `/api/send-email` with deliberately invalid recipient: now correctly returns HTTP 502 with `{"success":false,"error":"Invalid `to` field..."}` instead of the previous false `success:true`

https://claude.ai/code/session_017qWECM7UyEWpbYWpLu8tFh