### PR TITLE
fix: order confirmation and status emails now go to account email

### DIFF
--- a/app/(shop)/cart/[cartId]/page.js
+++ b/app/(shop)/cart/[cartId]/page.js
@@ -8,7 +8,6 @@ import { toast } from "react-toastify";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { getCartItemById } from "@/actions/cart-utils";
-import { sendEmail } from "@/actions/contact";
 import { DetailSkeleton } from "@/components/skeletons";
 
 const Checkout = () => {
@@ -72,86 +71,10 @@ const Checkout = () => {
     }
   }, [cartId, sessionStatus, refetch]);
 
-  // Mutation to create an order and send email
+  // Mutation to create an order - confirmation email is sent server-side
+  // in POST /api/orders, to the logged-in account's email address
   const orderMutation = useMutation({
-    mutationFn: async (orderData) => {
-      const orderResponse = await createOrder(orderData);
-      // Prepare email content
-      const emailHtml = `
-        <h1 style="color: #0087de;">SwiftCart Order Confirmation</h1>
-        <h2>Order Overview</h2>
-        <p><strong>Order ID:</strong> ${orderResponse?.order?._id}</p>
-        <p><strong>Placed on:</strong> ${new Date(orderResponse?.order?.createdAt).toLocaleDateString()}</p>
-        <p><strong>Status:</strong> ${orderResponse?.order?.status}</p>
-        
-        <h2>Shipping Details</h2>
-        <p><strong>Name:</strong> ${orderResponse?.order?.shippingDetails?.firstName} ${orderResponse?.order?.shippingDetails?.lastName}</p>
-        ${
-          orderResponse?.order?.shippingDetails?.company
-            ? `<p><strong>Company:</strong> ${orderResponse.order.shippingDetails.company}</p>`
-            : ""
-        }
-        <p><strong>Address:</strong> ${orderResponse?.order?.shippingDetails?.address}</p>
-        <p><strong>City, Country:</strong> ${orderResponse?.order?.shippingDetails?.city}, ${orderResponse?.order?.shippingDetails?.country}</p>
-        <p><strong>Phone:</strong> ${orderResponse?.order?.shippingDetails?.phone}</p>
-        <p><strong>Email:</strong> ${orderResponse?.order?.shippingDetails?.email}</p>
-        
-        <h2>Payment Information</h2>
-        <p><strong>Payment Method:</strong> ${orderResponse?.order?.paymentDetails?.paymentMethod?.toUpperCase()}</p>
-        <p><strong>Card:</strong> **** **** **** ${orderResponse?.order?.paymentDetails?.cardLast4}</p>
-        
-        <h2>Items</h2>
-        <table style="width: 100%; border-collapse: collapse;">
-          <thead>
-            <tr style="background-color: #e6f0fa;">
-              <th style="border: 1px solid #ddd; padding: 8px;">Product</th>
-              <th style="border: 1px solid #ddd; padding: 8px;">Quantity</th>
-              <th style="border: 1px solid #ddd; padding: 8px;">Total</th>
-            </tr>
-          </thead>
-          <tbody>
-            ${orderResponse?.order?.items
-              ?.map(
-                (item) => `
-                  <tr>
-                    <td style="border: 1px solid #ddd; padding: 8px;">${item?.product?.title || "Product"}</td>
-                    <td style="border: 1px solid #ddd; padding: 8px;">${item?.quantity}</td>
-                    <td style="border: 1px solid #ddd; padding: 8px;">$${(item?.price * item?.quantity).toFixed(2)}</td>
-                  </tr>
-                `
-              )
-              .join("")}
-          </tbody>
-        </table>
-        
-        <h2>Order Summary</h2>
-        <p><strong>Subtotal:</strong> $${orderResponse?.order?.subtotal?.toFixed(2)}</p>
-        <p><strong>Shipping:</strong> ${
-          orderResponse?.order?.shipping === 0
-            ? "Free"
-            : `$${orderResponse?.order?.shipping?.toFixed(2)}`
-        }</p>
-        <p><strong>Total:</strong> $${orderResponse?.order?.total?.toFixed(2)}</p>
-        
-        <p style="color: #0087de;">Thank you for shopping with SwiftCart!</p>
-        <p style="color: #0087de;">Contact us: <a href="mailto:support@swiftcart.com">support@swiftcart.com</a></p>
-      `;
-      // Send confirmation email - failure here shouldn't fail the whole
-      // order, the order is already placed at this point.
-      let emailSent = true;
-      try {
-        const emailResult = await sendEmail({
-          to: orderResponse?.order?.shippingDetails?.email,
-          subject: `SwiftCart Order Confirmation - ${orderResponse?.order?._id}`,
-          html: emailHtml,
-        });
-        emailSent = !!emailResult?.success;
-      } catch (emailError) {
-        console.error("Error sending confirmation email:", emailError);
-        emailSent = false;
-      }
-      return { ...orderResponse, emailSent };
-    },
+    mutationFn: (orderData) => createOrder(orderData),
     onSuccess: (data) => {
       toast.success(
         data?.emailSent

--- a/app/api/orders/route.js
+++ b/app/api/orders/route.js
@@ -1,9 +1,99 @@
 import { NextResponse } from "next/server";
+import { Resend } from "resend";
 import { session } from "@/actions/auth-utils";
 import { dbConnect } from "@/service/mongo";
 import { Order } from "@/models/order-model";
 import { Cart } from "@/models/cart-model";
 import { Product } from "@/models/product-model";
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+function orderConfirmationHtml(order) {
+  return `
+    <h1 style="color: #0087de;">SwiftCart Order Confirmation</h1>
+    <h2>Order Overview</h2>
+    <p><strong>Order ID:</strong> ${order._id}</p>
+    <p><strong>Placed on:</strong> ${new Date(order.createdAt).toLocaleDateString()}</p>
+    <p><strong>Status:</strong> ${order.status}</p>
+
+    <h2>Shipping Details</h2>
+    <p><strong>Name:</strong> ${order.shippingDetails?.firstName} ${order.shippingDetails?.lastName}</p>
+    ${order.shippingDetails?.company ? `<p><strong>Company:</strong> ${order.shippingDetails.company}</p>` : ""}
+    <p><strong>Address:</strong> ${order.shippingDetails?.address}</p>
+    <p><strong>City, Country:</strong> ${order.shippingDetails?.city}, ${order.shippingDetails?.country}</p>
+    <p><strong>Phone:</strong> ${order.shippingDetails?.phone}</p>
+
+    <h2>Payment Information</h2>
+    <p><strong>Payment Method:</strong> ${order.paymentDetails?.paymentMethod?.toUpperCase()}</p>
+    <p><strong>Card:</strong> **** **** **** ${order.paymentDetails?.cardLast4}</p>
+
+    <h2>Items</h2>
+    <table style="width: 100%; border-collapse: collapse;">
+      <thead>
+        <tr style="background-color: #e6f0fa;">
+          <th style="border: 1px solid #ddd; padding: 8px;">Product</th>
+          <th style="border: 1px solid #ddd; padding: 8px;">Quantity</th>
+          <th style="border: 1px solid #ddd; padding: 8px;">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${order.items
+          ?.map(
+            (item) => `
+              <tr>
+                <td style="border: 1px solid #ddd; padding: 8px;">${item.product?.title || "Product"}</td>
+                <td style="border: 1px solid #ddd; padding: 8px;">${item.quantity}</td>
+                <td style="border: 1px solid #ddd; padding: 8px;">$${(item.price * item.quantity).toFixed(2)}</td>
+              </tr>
+            `
+          )
+          .join("")}
+      </tbody>
+    </table>
+
+    <h2>Order Summary</h2>
+    <p><strong>Subtotal:</strong> $${order.subtotal?.toFixed(2)}</p>
+    <p><strong>Shipping:</strong> ${order.shipping === 0 ? "Free" : `$${order.shipping?.toFixed(2)}`}</p>
+    <p><strong>Total:</strong> $${order.total?.toFixed(2)}</p>
+
+    <p style="color: #0087de;">Thank you for shopping with SwiftCart!</p>
+    <p style="color: #0087de;">Contact us: <a href="mailto:support@swiftcart.com">support@swiftcart.com</a></p>
+  `;
+}
+
+function orderStatusUpdateHtml(order) {
+  return `
+    <h1 style="color: #0087de;">SwiftCart Order Update</h1>
+    <p>Hi ${order.shippingDetails?.firstName || "there"},</p>
+    <p>Your order <strong>${order._id}</strong> is now:</p>
+    <p style="font-size: 18px;"><strong>${order.status}</strong></p>
+    <p><strong>Total:</strong> $${order.total?.toFixed(2)}</p>
+    <p style="color: #0087de;">Thank you for shopping with SwiftCart!</p>
+    <p style="color: #0087de;">Contact us: <a href="mailto:support@swiftcart.com">support@swiftcart.com</a></p>
+  `;
+}
+
+// Transactional order emails always go to the logged-in account's email,
+// not shippingDetails.email - the shipping form field can be edited to
+// something other than the account holder's own address.
+async function sendOrderEmail({ to, subject, html }) {
+  try {
+    const emailResponse = await resend.emails.send({
+      from: "SwiftCart <noreply@ashrafulislam.im>",
+      to,
+      subject,
+      html,
+    });
+    if (emailResponse.error) {
+      console.error("Resend rejected order email:", emailResponse.error);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error("Error sending order email:", error);
+    return false;
+  }
+}
 
 export async function POST(request) {
   try {
@@ -88,7 +178,16 @@ export async function POST(request) {
 
     await order.populate("items.product");
 
-    return NextResponse.json({ message: "Order placed successfully", order }, { status: 201 });
+    const emailSent = await sendOrderEmail({
+      to: userSession.user.email,
+      subject: `SwiftCart Order Confirmation - ${order._id}`,
+      html: orderConfirmationHtml(order),
+    });
+
+    return NextResponse.json(
+      { message: "Order placed successfully", order, emailSent },
+      { status: 201 }
+    );
   } catch (error) {
     console.error("Error creating order:", error);
     return NextResponse.json({ error: "Failed to create order" }, { status: 500 });
@@ -180,7 +279,7 @@ export async function PATCH(request) {
     await dbConnect();
 
     // Find and update the order
-    const order = await Order.findById(orderId);
+    const order = await Order.findById(orderId).populate("user", "email");
     if (!order) {
       return NextResponse.json({ error: "Order not found" }, { status: 404 });
     }
@@ -188,7 +287,16 @@ export async function PATCH(request) {
     order.status = status;
     await order.save();
 
-    return NextResponse.json({ message: "Order updated successfully", order }, { status: 200 });
+    const emailSent = await sendOrderEmail({
+      to: order.user?.email,
+      subject: `SwiftCart Order Update - ${order._id}`,
+      html: orderStatusUpdateHtml(order),
+    });
+
+    return NextResponse.json(
+      { message: "Order updated successfully", order, emailSent },
+      { status: 200 }
+    );
   } catch (error) {
     console.error("Error updating order:", error);
     return NextResponse.json({ error: "Failed to update order" }, { status: 500 });

--- a/app/dashboard/orders/page.js
+++ b/app/dashboard/orders/page.js
@@ -98,13 +98,18 @@ const OrderList = () => {
   // Mutation for updating order status
   const mutation = useMutation({
     mutationFn: updateOrderStatus,
-    onSuccess: () => {
+    onSuccess: (data) => {
       // Refetch orders to update the UI
       queryClient.invalidateQueries(["orders", currentPage]);
-      toast.success("Order status updated successfully", {
-        position: "top-right",
-        autoClose: 3000,
-      });
+      toast.success(
+        data?.emailSent
+          ? "Order status updated and customer notified by email"
+          : "Order status updated, but we couldn't email the customer",
+        {
+          position: "top-right",
+          autoClose: 3000,
+        }
+      );
     },
     onError: (error) => {
       toast.error(`Failed to update order: ${error.message}`, {


### PR DESCRIPTION
## Summary
- Order confirmation and status-update emails were sent to `shippingDetails.email` (the checkout form's editable field), not the logged-in customer's account email. If that field diverged from the account email — edited by the customer, or seeded/test data — the account holder never got the email.
- Confirmation email now sent server-side in `POST /api/orders`, addressed to `userSession.user.email`.
- Status-update email added to `PATCH /api/orders` (didn't exist before), addressed to `order.user.email` via populate, sent whenever an admin changes order status.
- Both routes return `emailSent`; UI toasts reflect actual delivery outcome instead of assuming success.

## Test plan
- [x] `npx eslint` clean on all 3 changed files
- [x] `npx vitest run` — 6/6 passing
- [x] Verified `Order.findById(...).populate("user", "email")` resolves the real account email from a real order
- [x] Verified confirmation template renders and delivers via Resend (plus-addressed Gmail, arrived in INBOX)
- [x] Verified status-update template renders and delivers via Resend (plus-addressed Gmail, arrived in INBOX)

https://claude.ai/code/session_017qWECM7UyEWpbYWpLu8tFh