### PR TITLE
feat: add Best Sellers, Deals, Testimonials, FAQ sections to homepage

### DIFF
--- a/actions/products/index.js
+++ b/actions/products/index.js
@@ -7,9 +7,22 @@ export const addProduct = async (productData) => {
 };
 
 //get all products
-export const getProducts = async ({ limit, sort, category } = {}) => {
+export const getProducts = async ({ limit, sort, category, discounted } = {}) => {
     const response = await api.get("/products", {
-      params: { limit, sort, category },
+      params: { limit, sort, category, discounted },
+      headers: {
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0'
+      },
+    });
+    return response.data;
+  };
+
+  //get best-selling products (by units sold across orders)
+  export const getBestSellers = async ({ limit } = {}) => {
+    const response = await api.get("/products/best-sellers", {
+      params: { limit },
       headers: {
         'Cache-Control': 'no-cache, no-store, must-revalidate',
         'Pragma': 'no-cache',

--- a/app/(shop)/page.js
+++ b/app/(shop)/page.js
@@ -1,10 +1,14 @@
 import Ads from "@/components/Ads";
 import Banner from "@/components/Banner";
+import BestSellers from "@/components/BestSellers";
+import Deals from "@/components/Deals";
+import FAQHome from "@/components/FAQHome";
 import FeaturedProduct from "@/components/FeaturedProduct";
 import Features from "@/components/Features";
 import NewArrival from "@/components/NewArrival";
 import NewsLetter from "@/components/NewsLetter";
 import ShopByCategory from "@/components/ShopByCategory";
+import Testimonials from "@/components/Testimonials";
 import Trending from "@/components/Trending";
 
 export const metadata = {
@@ -25,9 +29,13 @@ export default function Home() {
       <Features />
       <ShopByCategory />
       <NewArrival />
+      <BestSellers />
       <FeaturedProduct />
+      <Deals />
       <Ads />
       <Trending />
+      <Testimonials />
+      <FAQHome />
       <NewsLetter />
     </>
   );

--- a/app/api/products/best-sellers/route.js
+++ b/app/api/products/best-sellers/route.js
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { dbConnect } from "@/service/mongo";
+import { Order } from "@/models/order-model";
+import { Product } from "@/models/product-model";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req) {
+  try {
+    await dbConnect();
+
+    const limit = parseInt(req.nextUrl.searchParams.get("limit")) || 8;
+
+    const ranked = await Order.aggregate([
+      { $match: { status: { $ne: "Cancelled" } } },
+      { $unwind: "$items" },
+      { $group: { _id: "$items.product", unitsSold: { $sum: "$items.quantity" } } },
+      { $sort: { unitsSold: -1 } },
+      { $limit: limit },
+    ]);
+
+    const productIds = ranked.map((r) => r._id);
+    const products = await Product.find({ _id: { $in: productIds } }).lean();
+
+    const unitsSoldById = new Map(ranked.map((r) => [r._id.toString(), r.unitsSold]));
+    const ordered = productIds
+      .map((id) => products.find((p) => p._id.toString() === id.toString()))
+      .filter(Boolean)
+      .map((product) => ({
+        ...product,
+        unitsSold: unitsSoldById.get(product._id.toString()),
+      }));
+
+    return NextResponse.json({ products: ordered }, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching best sellers:", error);
+    return NextResponse.json({ error: "Failed to fetch best sellers" }, { status: 500 });
+  }
+}

--- a/app/api/products/route.js
+++ b/app/api/products/route.js
@@ -12,11 +12,16 @@ export async function GET(req) {
         const limit = parseInt(searchParams.get("limit")) || 0;
         const sort = searchParams.get("sort");
         const category = searchParams.get("category") || null;
-    
+        const discounted = searchParams.get("discounted") === "true";
+
         let query = Product.find();
 
         if (category) {
           query = query.where("category").regex(new RegExp(`^${category}$`, "i"));
+        }
+
+        if (discounted) {
+          query = query.where({ $expr: { $gt: ["$originalPrice", "$price"] } });
         }
 
         query = query.sort(sort);

--- a/components/BestSellers.jsx
+++ b/components/BestSellers.jsx
@@ -1,0 +1,209 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import Link from "next/link";
+import { getBestSellers } from "@/actions/products";
+import { getWishlist, updateWishlist } from "@/actions/wishlist";
+import { addToCart, getCart } from "@/actions/cart-utils";
+import { useRouter } from "next/navigation";
+import ProductCard from "./ProductCard";
+import { session } from "@/actions/auth-utils";
+
+const SkeletonProductCard = () => (
+  <div className="bg-white shadow-md rounded-lg overflow-hidden h-[400px] w-full flex flex-col animate-pulse">
+    <div className="relative w-full h-48">
+      <div className="w-full h-full bg-gray-200" />
+    </div>
+    <div className="p-4 flex flex-col flex-grow">
+      <div className="h-6 bg-gray-200 rounded w-3/4 mb-2" />
+      <div className="flex items-center mb-2">
+        <div className="h-5 bg-gray-200 rounded w-16 mr-2" />
+        <div className="h-4 bg-gray-200 rounded w-12" />
+      </div>
+      <div className="flex items-center mb-2">
+        <div className="flex gap-1">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="w-4 h-4 bg-gray-200 rounded-full" />
+          ))}
+        </div>
+        <div className="h-3 bg-gray-200 rounded w-8 ml-2" />
+      </div>
+      <div className="mt-auto block w-full py-2 bg-gray-200 rounded-lg h-10" />
+    </div>
+  </div>
+);
+
+const BestSellers = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    async function fetchUser() {
+      const res = await session();
+      if (res) {
+        setUser(res.user);
+      }
+    }
+    fetchUser();
+  }, []);
+
+  const { data: productsData, error: productsError, isLoading: productsLoading } = useQuery({
+    queryKey: ["bestSellers"],
+    queryFn: () => getBestSellers({ limit: 8 }),
+    onError: (error) => {
+      toast.error(`Error fetching best sellers: ${error.message}`, {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+  });
+
+  const { data: wishlistData, isLoading: wishlistLoading } = useQuery({
+    queryKey: ["wishlist"],
+    queryFn: getWishlist,
+    enabled: !!user,
+  });
+
+  const { data: cartData, isLoading: cartLoading } = useQuery({
+    queryKey: ["cart"],
+    queryFn: getCart,
+    enabled: !!user,
+  });
+
+  const wishlistMutation = useMutation({
+    mutationFn: ({ productId, action }) => updateWishlist(productId, action),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(["wishlist"]);
+      toast.success(data.message, { position: "top-right", autoClose: 3000 });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to manage your wishlist.", {
+          position: "top-right",
+          autoClose: 3000,
+        });
+        setTimeout(() => router.push("/login"), 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, { position: "top-right", autoClose: 3000 });
+      }
+    },
+  });
+
+  const cartMutation = useMutation({
+    mutationFn: ({ productId, quantity }) => addToCart(productId, quantity),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["cart"]);
+      toast.success("Product added to cart successfully!", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to add to cart.", { position: "top-right", autoClose: 3000 });
+        setTimeout(() => router.push("/login"), 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, { position: "top-right", autoClose: 3000 });
+      }
+    },
+  });
+
+  const handleWishlistToggle = (productId, e) => {
+    e.preventDefault();
+    if (!user) {
+      toast.error("Please log in to manage your wishlist.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      setTimeout(() => router.push("/login"), 3000);
+      return;
+    }
+    if (wishlistLoading || wishlistMutation.isPending) return;
+
+    const isInWishlist = wishlistData?.wishlist?.some(
+      (item) => item._id.toString() === productId
+    );
+    wishlistMutation.mutate({ productId, action: isInWishlist ? "remove" : "add" });
+  };
+
+  const isInCart = (productId) =>
+    cartData?.cart?.items?.some((item) => item.product._id.toString() === productId) || false;
+
+  const handleCartAction = (productId, e) => {
+    e.preventDefault();
+    if (!user) {
+      toast.error("Please log in to add to cart.", { position: "top-right", autoClose: 3000 });
+      setTimeout(() => router.push("/login"), 3000);
+      return;
+    }
+    if (isInCart(productId)) {
+      router.push("/cart");
+    } else {
+      if (cartMutation.isPending) return;
+      cartMutation.mutate({ productId, quantity: 1 });
+    }
+  };
+
+  if (productsLoading) {
+    return (
+      <div className="container pb-16">
+        <h2 className="text-2xl font-medium text-gray-800 uppercase mb-6">
+          Best Sellers
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <SkeletonProductCard key={index} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (productsError) {
+    return null;
+  }
+
+  const products = productsData?.products || [];
+
+  if (products.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="container pb-16">
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-medium text-gray-800 uppercase">
+          Best Sellers
+        </h2>
+        <Link
+          href="/products"
+          className="text-sm text-primary hover:underline uppercase font-medium"
+        >
+          View All
+        </Link>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+        {products.map((product) => (
+          <ProductCard
+            key={product._id}
+            product={product}
+            wishlistData={wishlistData}
+            wishlistLoading={wishlistLoading}
+            mutation={wishlistMutation}
+            handleWishlistToggle={handleWishlistToggle}
+            cartData={cartData}
+            cartLoading={cartLoading}
+            cartMutation={cartMutation}
+            handleCartAction={handleCartAction}
+            isInCart={isInCart}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default BestSellers;

--- a/components/Deals.jsx
+++ b/components/Deals.jsx
@@ -1,0 +1,202 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "react-toastify";
+import { getProducts } from "@/actions/products";
+import { getWishlist, updateWishlist } from "@/actions/wishlist";
+import { addToCart, getCart } from "@/actions/cart-utils";
+import { useRouter } from "next/navigation";
+import ProductCard from "./ProductCard";
+import { session } from "@/actions/auth-utils";
+
+const SkeletonProductCard = () => (
+  <div className="bg-white shadow-md rounded-lg overflow-hidden h-[400px] w-full flex flex-col animate-pulse">
+    <div className="relative w-full h-48">
+      <div className="w-full h-full bg-gray-200" />
+    </div>
+    <div className="p-4 flex flex-col flex-grow">
+      <div className="h-6 bg-gray-200 rounded w-3/4 mb-2" />
+      <div className="flex items-center mb-2">
+        <div className="h-5 bg-gray-200 rounded w-16 mr-2" />
+        <div className="h-4 bg-gray-200 rounded w-12" />
+      </div>
+      <div className="flex items-center mb-2">
+        <div className="flex gap-1">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div key={index} className="w-4 h-4 bg-gray-200 rounded-full" />
+          ))}
+        </div>
+        <div className="h-3 bg-gray-200 rounded w-8 ml-2" />
+      </div>
+      <div className="mt-auto block w-full py-2 bg-gray-200 rounded-lg h-10" />
+    </div>
+  </div>
+);
+
+const Deals = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    async function fetchUser() {
+      const res = await session();
+      if (res) {
+        setUser(res.user);
+      }
+    }
+    fetchUser();
+  }, []);
+
+  const { data: productsData, error: productsError, isLoading: productsLoading } = useQuery({
+    queryKey: ["deals"],
+    queryFn: () => getProducts({ limit: 8, discounted: true }),
+    onError: (error) => {
+      toast.error(`Error fetching deals: ${error.message}`, {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+  });
+
+  const { data: wishlistData, isLoading: wishlistLoading } = useQuery({
+    queryKey: ["wishlist"],
+    queryFn: getWishlist,
+    enabled: !!user,
+  });
+
+  const { data: cartData, isLoading: cartLoading } = useQuery({
+    queryKey: ["cart"],
+    queryFn: getCart,
+    enabled: !!user,
+  });
+
+  const wishlistMutation = useMutation({
+    mutationFn: ({ productId, action }) => updateWishlist(productId, action),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(["wishlist"]);
+      toast.success(data.message, { position: "top-right", autoClose: 3000 });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to manage your wishlist.", {
+          position: "top-right",
+          autoClose: 3000,
+        });
+        setTimeout(() => router.push("/login"), 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, { position: "top-right", autoClose: 3000 });
+      }
+    },
+  });
+
+  const cartMutation = useMutation({
+    mutationFn: ({ productId, quantity }) => addToCart(productId, quantity),
+    onSuccess: () => {
+      queryClient.invalidateQueries(["cart"]);
+      toast.success("Product added to cart successfully!", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to add to cart.", { position: "top-right", autoClose: 3000 });
+        setTimeout(() => router.push("/login"), 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, { position: "top-right", autoClose: 3000 });
+      }
+    },
+  });
+
+  const handleWishlistToggle = (productId, e) => {
+    e.preventDefault();
+    if (!user) {
+      toast.error("Please log in to manage your wishlist.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      setTimeout(() => router.push("/login"), 3000);
+      return;
+    }
+    if (wishlistLoading || wishlistMutation.isPending) return;
+
+    const isInWishlist = wishlistData?.wishlist?.some(
+      (item) => item._id.toString() === productId
+    );
+    wishlistMutation.mutate({ productId, action: isInWishlist ? "remove" : "add" });
+  };
+
+  const isInCart = (productId) =>
+    cartData?.cart?.items?.some((item) => item.product._id.toString() === productId) || false;
+
+  const handleCartAction = (productId, e) => {
+    e.preventDefault();
+    if (!user) {
+      toast.error("Please log in to add to cart.", { position: "top-right", autoClose: 3000 });
+      setTimeout(() => router.push("/login"), 3000);
+      return;
+    }
+    if (isInCart(productId)) {
+      router.push("/cart");
+    } else {
+      if (cartMutation.isPending) return;
+      cartMutation.mutate({ productId, quantity: 1 });
+    }
+  };
+
+  if (productsLoading) {
+    return (
+      <div className="container pb-16">
+        <h2 className="text-2xl font-medium text-gray-800 uppercase mb-6">
+          Deals of the Week
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <SkeletonProductCard key={index} />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (productsError) {
+    return null;
+  }
+
+  const products = productsData?.products || [];
+
+  // No products currently discounted - skip the section instead of
+  // showing an empty "Deals" block.
+  if (products.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="container pb-16 bg-gray-50">
+      <h2 className="text-2xl font-medium text-gray-800 uppercase mb-6 pt-10">
+        Deals of the Week
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 pb-4">
+        {products.map((product) => (
+          <ProductCard
+            key={product._id}
+            product={product}
+            wishlistData={wishlistData}
+            wishlistLoading={wishlistLoading}
+            mutation={wishlistMutation}
+            handleWishlistToggle={handleWishlistToggle}
+            cartData={cartData}
+            cartLoading={cartLoading}
+            cartMutation={cartMutation}
+            handleCartAction={handleCartAction}
+            isInCart={isInCart}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Deals;

--- a/components/FAQHome.jsx
+++ b/components/FAQHome.jsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+
+const faqs = [
+  {
+    question: "How long does shipping take?",
+    answer:
+      "Most orders arrive within 3-7 business days. Orders over $200 ship free; you'll get a confirmation email with tracking details as soon as your order leaves the warehouse.",
+  },
+  {
+    question: "What's your return policy?",
+    answer:
+      "You can return most items within 30 days of delivery for a full refund, as long as they're unused and in original packaging.",
+  },
+  {
+    question: "What payment methods do you accept?",
+    answer:
+      "We accept all major credit and debit cards. Payment is processed securely at checkout.",
+  },
+  {
+    question: "How can I track my order?",
+    answer:
+      "Once your order ships, you'll receive an email update. You can also check order status any time from your account's Order History page.",
+  },
+  {
+    question: "Can I change or cancel my order after placing it?",
+    answer:
+      "Contact us as soon as possible after placing your order. We can usually make changes or cancel if the order hasn't shipped yet.",
+  },
+];
+
+export default function FAQHome() {
+  const [openIndex, setOpenIndex] = useState(0);
+
+  return (
+    <div className="container pb-16">
+      <h2 className="text-2xl font-medium text-gray-800 uppercase mb-6 text-center">
+        Frequently Asked Questions
+      </h2>
+      <div className="max-w-3xl mx-auto divide-y divide-gray-200 border-t border-b border-gray-200">
+        {faqs.map((faq, index) => {
+          const isOpen = openIndex === index;
+          return (
+            <div key={faq.question}>
+              <button
+                type="button"
+                onClick={() => setOpenIndex(isOpen ? -1 : index)}
+                aria-expanded={isOpen}
+                className="w-full flex items-center justify-between py-4 text-left"
+              >
+                <span className="font-medium text-gray-800">{faq.question}</span>
+                <svg
+                  className={`w-5 h-5 flex-shrink-0 text-gray-500 transition-transform ${
+                    isOpen ? "rotate-180" : ""
+                  }`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
+              {isOpen && (
+                <p className="text-gray-600 text-sm pb-4 pr-8">{faq.answer}</p>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/Testimonials.jsx
+++ b/components/Testimonials.jsx
@@ -1,0 +1,78 @@
+import { dbConnect } from "@/service/mongo";
+import { Review } from "@/models/review-model";
+import "@/models/user-model";
+import "@/models/product-model";
+
+async function getTopReviews() {
+  try {
+    await dbConnect();
+    const reviews = await Review.find({ rating: { $gte: 4 } })
+      .sort({ rating: -1, createdAt: -1 })
+      .limit(6)
+      .populate("userId", "name")
+      .populate("productId", "title")
+      .lean();
+    return JSON.parse(JSON.stringify(reviews));
+  } catch {
+    return [];
+  }
+}
+
+function Stars({ rating }) {
+  return (
+    <div className="flex gap-0.5 text-primary" aria-label={`${rating} out of 5 stars`}>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <svg
+          key={i}
+          viewBox="0 0 20 20"
+          fill={i < rating ? "currentColor" : "none"}
+          stroke="currentColor"
+          className="w-4 h-4"
+        >
+          <path d="M10 1.5l2.6 5.6 6.1.6-4.6 4.1 1.3 6-5.4-3.1-5.4 3.1 1.3-6L1.3 7.7l6.1-.6L10 1.5z" />
+        </svg>
+      ))}
+    </div>
+  );
+}
+
+const Testimonials = async () => {
+  const reviews = await getTopReviews();
+
+  if (reviews.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="container pb-16">
+      <h2 className="text-2xl font-medium text-gray-800 uppercase mb-6 text-center">
+        What Our Customers Say
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {reviews.map((review) => (
+          <div
+            key={review._id}
+            className="bg-white border border-gray-100 shadow-sm rounded-lg p-6 flex flex-col gap-3"
+          >
+            <Stars rating={review.rating} />
+            <p className="text-gray-600 text-sm leading-relaxed line-clamp-4">
+              &quot;{review.review}&quot;
+            </p>
+            <div className="mt-auto pt-2 border-t border-gray-100">
+              <p className="font-medium text-gray-800">
+                {review.userId?.name || "SwiftCart Customer"}
+              </p>
+              {review.productId?.title && (
+                <p className="text-xs text-gray-400">
+                  on {review.productId.title}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Testimonials;


### PR DESCRIPTION
## Summary
- **Best Sellers** — new `/api/products/best-sellers` endpoint, aggregates `Order.items` by product (excludes Cancelled) and ranks by units sold. Distinct signal from the existing Trending section (view-count `popularityScore`).
- **Deals of the Week** — `discounted=true` filter added to `/api/products` (`originalPrice > price`), reuses `ProductCard`'s existing strikethrough-price UI. Renders nothing if no products are currently discounted.
- **Testimonials** — real reviews (rating ≥ 4), fetched server-side directly (no client round trip, no interactivity needed there unlike the product-grid sections).
- **FAQ** — static accordion (shipping, returns, payment, tracking, cancellation).

## Test plan
- [x] `npx eslint` clean
- [x] `npx vitest run` — 6/6 passing
- [x] Isolated dev server: homepage renders all 4 new sections, both new/extended API endpoints verified against real DB data, full page renders end-to-end with no error boundary triggered

https://claude.ai/code/session_017qWECM7UyEWpbYWpLu8tFh