### PR TITLE
fix: stop relying on unset ENVIRONMENT var for MongoDBAdapter db name

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -11,7 +11,7 @@ import { authConfig } from "./auth.config";
 
 export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
   ...authConfig,
-  adapter: MongoDBAdapter(mongoClientPromise, { databaseName: process.env.ENVIRONMENT }),
+  adapter: MongoDBAdapter(mongoClientPromise),
   providers: [
     Credentials({
       credentials: {


### PR DESCRIPTION
## Summary
- `MongoDBAdapter(mongoClientPromise, { databaseName: process.env.ENVIRONMENT })` resolved `databaseName` to `undefined` — `ENVIRONMENT` is not set in `.env`/`.env.local`.
- It worked only by accident: `MongoClient.db(undefined)` falls back to the db name embedded in the connection string (`swiftcart`), same db Mongoose connects to.
- Landmine: setting `ENVIRONMENT` to any real value later (e.g. `production`) with no matching database would silently split OAuth user/account data into a different, empty database.
- Fix: drop the `databaseName` option so the adapter always falls back to the URI-derived db name — same source of truth Mongoose already uses.

## Test plan
- [x] Verified no other code relies on `databaseName` behavior
- [ ] Sign in with Google locally, confirm user still lands in `swiftcart.users` collection

https://claude.ai/code/session_018SiiBX1EJr2uWWURGpw569