### PR TITLE
fix: redirect after successful OAuth sign-in on login/register pages

### DIFF
--- a/app/(auth)/login/page.jsx
+++ b/app/(auth)/login/page.jsx
@@ -73,6 +73,10 @@ const LoginPage = () => {
           draggable: true,
           progress: undefined,
         });
+        setTimeout(() => {
+          router.push("/");
+          router.refresh();
+        }, 2000);
       }
     } catch (error) {
       console.error("Error during Google sign-in:", error);
@@ -113,6 +117,10 @@ const LoginPage = () => {
           draggable: true,
           progress: undefined,
         });
+        setTimeout(() => {
+          router.push("/");
+          router.refresh();
+        }, 2000);
       }
     } catch (error) {
       console.error("Error during Facebook sign-in:", error);

--- a/app/(auth)/register/page.jsx
+++ b/app/(auth)/register/page.jsx
@@ -143,6 +143,10 @@ const RegisterPage = () => {
           draggable: true,
           progress: undefined,
         });
+        setTimeout(() => {
+          router.push("/");
+          router.refresh();
+        }, 2000);
       }
     } catch (error) {
       console.error("Error during Google sign-in:", error);


### PR DESCRIPTION
## Summary
- `handleGoogleSignIn` (register + login) and `handleFacebookSignIn` (login) showed a "Redirecting..." success toast after `signIn(..., { redirect: false })` resolved, but never called `router.push`.
- User stayed stuck on the auth page after a successful OAuth sign-in despite the toast claiming a redirect.
- Fix: mirror the existing email/password `handleSubmit` pattern — `router.push("/")` + `router.refresh()` after a 2s delay — in all three handlers.

## Test plan
- [ ] Sign up via Google on `/register`, confirm redirect to `/` after toast
- [ ] Sign in via Google on `/login`, confirm redirect to `/` after toast
- [ ] Sign in via Facebook on `/login`, confirm redirect to `/` after toast (button currently commented out in UI, logic still reachable if re-enabled)

https://claude.ai/code/session_018SiiBX1EJr2uWWURGpw569