### PR TITLE
fix: harden auth against account-lockout, role gap, brute force, enumeration

### DIFF
--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -2,9 +2,21 @@ import { NextResponse } from "next/server";
 import { dbConnect } from "@/service/mongo";
 import { User } from "@/models/user-model";
 import bcrypt from "bcryptjs";
+import { rateLimit, clientIp } from "@/service/rate-limit";
 
 export async function POST(req) {
   try {
+    const { allowed, retryAfterSeconds } = rateLimit(`register:${clientIp(req)}`, {
+      limit: 5,
+      windowMs: 5 * 60 * 1000,
+    });
+    if (!allowed) {
+      return NextResponse.json(
+        { message: "Too many registration attempts. Please try again later." },
+        { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
+      );
+    }
+
     await dbConnect();
 
     const { name, email, password, role } = await req.json();

--- a/auth.config.js
+++ b/auth.config.js
@@ -18,7 +18,7 @@ export const authConfig = {
     async jwt({ token, user }) {
       if (user) {
         token.sub = user.id;
-        token.role = user.role;
+        token.role = user.role ?? "user";
         if (user.image) {
           token.picture = user.image;
         }

--- a/auth.js
+++ b/auth.js
@@ -8,6 +8,7 @@ import mongoClientPromise from "./service/mongoClientPromise";
 import { dbConnect } from "./service/mongo";
 import { User } from "./models/user-model";
 import { authConfig } from "./auth.config";
+import { rateLimit, clientIp } from "./service/rate-limit";
 
 export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
   ...authConfig,
@@ -18,16 +19,24 @@ export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
         email: { label: "Email", type: "email" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, request) {
         if (!credentials?.email || !credentials?.password) {
           throw new Error("Email and password are required");
+        }
+
+        const { allowed } = rateLimit(`login:${clientIp(request)}:${credentials.email}`, {
+          limit: 5,
+          windowMs: 5 * 60 * 1000,
+        });
+        if (!allowed) {
+          throw new Error("Too many login attempts. Please try again later.");
         }
 
         await dbConnect();
         const user = await User.findOne({ email: credentials.email });
 
-        if (!user) {
-          throw new Error("User not found");
+        if (!user || !user.password) {
+          throw new Error("Invalid credentials");
         }
 
         const isMatch = await bcrypt.compare(credentials.password, user.password);
@@ -46,10 +55,12 @@ export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
     Google({
       clientId: process.env.AUTH_GOOGLE_ID,
       clientSecret: process.env.AUTH_GOOGLE_SECRET,
+      allowDangerousEmailAccountLinking: true,
     }),
     Facebook({
       clientId: process.env.AUTH_FACEBOOK_ID,
       clientSecret: process.env.AUTH_FACEBOOK_SECRET,
+      allowDangerousEmailAccountLinking: true,
       profile(profile) {
         return {
           id: profile.id,
@@ -83,7 +94,7 @@ export const { handlers: { GET, POST }, signIn, signOut, auth } = NextAuth({
     async jwt({ token, user }) {
       if (user) {
         token.sub = user.id;
-        token.role = user.role;
+        token.role = user.role ?? "user";
         if (user.image) {
           token.picture = user.image;
         }

--- a/service/rate-limit.js
+++ b/service/rate-limit.js
@@ -1,0 +1,25 @@
+// ponytail: in-memory fixed-window limiter, per-process only. Fine for a
+// single long-running server; on serverless/multi-instance (e.g. Vercel)
+// each instance keeps its own counters so the limit isn't global. Swap for
+// @upstash/ratelimit (or any Redis-backed limiter) if that gap matters.
+const buckets = new Map();
+
+export function rateLimit(key, { limit = 5, windowMs = 5 * 60 * 1000 } = {}) {
+  const now = Date.now();
+  const bucket = buckets.get(key);
+
+  if (!bucket || now > bucket.resetAt) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return { allowed: true };
+  }
+
+  bucket.count += 1;
+  if (bucket.count > limit) {
+    return { allowed: false, retryAfterSeconds: Math.ceil((bucket.resetAt - now) / 1000) };
+  }
+  return { allowed: true };
+}
+
+export function clientIp(request) {
+  return request?.headers?.get?.("x-forwarded-for")?.split(",")[0].trim() || "unknown";
+}


### PR DESCRIPTION
## Summary
Fixes 4 known auth flaws:

1. **Account-linking lockout** — credentials + OAuth users sharing an email would hit a MongoDB duplicate-key crash (or a dead-end where the OAuth user could never use credentials login). Added `allowDangerousEmailAccountLinking: true` on Google and Facebook providers so signing in with the same email auto-links to the existing account. Accepted trade-off: relies on the OAuth provider's email ownership verification instead of our own confirmation step (standard NextAuth trade-off, hence the flag's name).
2. **Missing role on OAuth users** — `MongoDBAdapter`-created users never got a `role` field, so `session.user.role` was `undefined` (happened to work since every check is `=== "admin"`, but fragile). Now defaults to `"user"` in the `jwt` callback in both `auth.js` and `auth.config.js`.
3. **No rate limiting** — `/api/register` and credentials `authorize()` had no throttling. Added a small in-memory fixed-window limiter (`service/rate-limit.js`, 5 attempts / 5 min, keyed by IP for register and IP+email for login). Documented ceiling: per-process only, doesn't share state across serverless instances — noted as a `ponytail:` comment with the upgrade path (Redis-backed limiter) if that gap matters at scale.
4. **User-enumeration via error messages** — `authorize()` threw distinct `"User not found"` vs `"Invalid credentials"`, letting an attacker probe which emails are registered. Collapsed to one generic `"Invalid credentials"` message, and added a guard so comparing against a missing password hash (an OAuth-only user attempting credentials login) fails cleanly instead of crashing inside `bcrypt.compare`.

## Test plan
- [ ] Register with email/password, then sign in with Google using the same email — should link, not crash
- [ ] Sign up fresh via Google, confirm `session.user.role === "user"` (previously `undefined`)
- [ ] Hit `/api/register` 6+ times quickly from the same IP — 6th should return 429
- [ ] Attempt credentials login 6+ times with wrong password for the same email — 6th should return the rate-limit error
- [ ] Attempt credentials login with a non-existent email vs a wrong password for a real email — both should show the same generic error
- [ ] Sign in with Google on an email that has no password (OAuth-only), then try credentials login for that email — should fail cleanly, no crash

https://claude.ai/code/session_018SiiBX1EJr2uWWURGpw569