### PR TITLE
fix: register user model before populate in reviews API

### DIFF
--- a/app/api/reviews/[productId]/route.js
+++ b/app/api/reviews/[productId]/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/service/mongo";
 import { Review } from "@/models/review-model";
+import "@/models/user-model";
 
 export async function GET(request, { params }) {
   try {


### PR DESCRIPTION
## Summary
- `/api/reviews/[productId]` called `Review.find().populate("userId", "name")` but never imported `user-model.js`, so mongoose never registered the `"users"` schema in that route's module graph.
- `.populate()` threw whenever a product had at least one review (products with zero reviews silently skipped populate and returned 200), caught by the generic error handler → 500 `{"error":"Internal server error"}`.
- Since #63 wired up a global react-query `onError` toast, this surfaced as a visible "Internal server error" toast top-right on the homepage (coincidentally near Wishlist/Cart icons — unrelated to those features, which are correctly session-gated).

## Fix
Add `import "@/models/user-model";` to register the model before populate runs, matching the existing pattern in `app/api/wishlist/route.js` and `app/api/cart/route.js`.

## Test plan
- [x] Verified locally: `GET /api/reviews/680fdcf34d5371f75bda1785` returned 500 before fix, 200 with populated `userId.name` after fix