### PR TITLE
fix: wishlist pagination/clear-all, price range UI, false login prompts, Shop nav

### DIFF
--- a/app/(shop)/cart/page.js
+++ b/app/(shop)/cart/page.js
@@ -17,7 +17,6 @@ import {
 import { getCart, removeFromCart, updateCartQuantity } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { session } from "@/actions/auth-utils";
 import LoadError from "@/components/LoadError";
 
 // Skeleton Loader for Cart Items
@@ -38,22 +37,15 @@ const SkeletonCartItem = () => (
 const CartPage = () => {
   const queryClient = useQueryClient();
   const { data: userSession, status } = useSession();
-  const [user, setUser] = useState(null);
-  
+  const user = userSession?.user;
+
   const router = useRouter();
 
   useEffect(() => {
-      async function fetchUser() {
-        const res = await session();
-        if(res) {
-          setUser(res.user);
-        }
-        if(!res?.user) {
-          router.push("/");
-        }
-      }
-      fetchUser();
-    }, [router]);
+    if (status === "unauthenticated") {
+      router.push("/");
+    }
+  }, [status, router]);
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(1);

--- a/app/(shop)/products/Products.jsx
+++ b/app/(shop)/products/Products.jsx
@@ -9,7 +9,6 @@ import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import ProductCard from "@/components/ProductCard";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
-import { session } from "@/actions/auth-utils";
 import { ProductGridSkeleton } from "@/components/skeletons";
 import LoadError from "@/components/LoadError";
 
@@ -28,17 +27,7 @@ const Products = ({ initialProducts }) => {
   });
   const [filteredProducts, setFilteredProducts] = useState([]);
   const [showFilters, setShowFilters] = useState(false);
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-          async function fetchUser() {
-            const res = await session();
-            if(res) {
-              setUser(res.user);
-            }
-          }
-          fetchUser();
-        }, []);
+  const user = userSession?.user;
 
   // Fetch products
   const { data, error, isLoading } = useQuery({
@@ -445,8 +434,8 @@ const Products = ({ initialProducts }) => {
                   </label>
                   <div className="flex items-center space-x-2">
                     <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-2 flex items-center pointer-events-none">
-                        <span className="text-gray-500 sm:text-xs">$</span>
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <span className="text-gray-500 text-sm">$</span>
                       </div>
                       <input
                         type="number"
@@ -454,15 +443,15 @@ const Products = ({ initialProducts }) => {
                         onChange={(e) =>
                           handlePriceRangeChange("min", e.target.value)
                         }
-                        className="block w-full pl-5 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
+                        className="block w-full pl-7 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
                         placeholder="Min"
                         min="0"
                       />
                     </div>
                     <span className="text-gray-500 text-sm">to</span>
                     <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-2 flex items-center pointer-events-none">
-                        <span className="text-gray-500 sm:text-xs">$</span>
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <span className="text-gray-500 text-sm">$</span>
                       </div>
                       <input
                         type="number"
@@ -470,7 +459,7 @@ const Products = ({ initialProducts }) => {
                         onChange={(e) =>
                           handlePriceRangeChange("max", e.target.value)
                         }
-                        className="block w-full pl-5 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
+                        className="block w-full pl-7 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
                         placeholder="Max"
                         min="0"
                         max={maxProductPrice}

--- a/app/(shop)/products/[id]/ProductDetails.jsx
+++ b/app/(shop)/products/[id]/ProductDetails.jsx
@@ -22,7 +22,6 @@ import {
 import { FaXTwitter } from "react-icons/fa6";
 import { ProductDetailSkeleton } from "@/components/skeletons";
 import ProductImageGallery from "@/components/ProductImageGallery";
-import { session } from "@/actions/auth-utils";
 import LoadError from "@/components/LoadError";
 
 const ProductDetails = ({ params, initialProduct }) => {
@@ -30,20 +29,10 @@ const ProductDetails = ({ params, initialProduct }) => {
   const [quantity, setQuantity] = useState(1);
   const [reviewText, setReviewText] = useState("");
   const [rating, setRating] = useState(0);
-  const [user, setUser] = useState(null);
   const queryClient = useQueryClient();
   const { data: userSession } = useSession();
+  const user = userSession?.user;
   const router = useRouter();
-
-  useEffect(() => {
-        async function fetchUser() {
-          const res = await session();
-          if(res) {
-            setUser(res.user);
-          }
-        }
-        fetchUser();
-      }, []);
 
   // Fetch product details
   const { data: productData, error: productError, isLoading: productLoading } = useQuery({

--- a/app/(shop)/wishlist/page.js
+++ b/app/(shop)/wishlist/page.js
@@ -18,7 +18,6 @@ import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { session } from "@/actions/auth-utils";
 import LoadError from "@/components/LoadError";
 
 // Skeleton Loader for Wishlist Items
@@ -38,23 +37,16 @@ const SkeletonWishlistItem = () => (
 const Wishlist = () => {
   const queryClient = useQueryClient();
   const { data: userSession, status } = useSession();
-  const [user, setUser] = useState(null);
+  const user = userSession?.user;
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 10;
+  const itemsPerPage = 12;
 
   useEffect(() => {
-    async function fetchUser() {
-      const res = await session();
-      if(res) {
-        setUser(res.user);
-      }
-      if (!res?.user) {
-        router.push("/");
-      }
+    if (status === "unauthenticated") {
+      router.push("/");
     }
-    fetchUser();
-  }, [router]);
+  }, [status, router]);
 
   // Fetch wishlist
   const { data, error, isLoading } = useQuery({
@@ -267,32 +259,59 @@ const Wishlist = () => {
             </div>
           </div>
 
-          {/* Right Section (Button) */}
+          {/* Right Section (Buttons) */}
           {wishlist.length > 0 && (
-            <button
-              onClick={() => {
-                wishlist.forEach((product) => {
+            <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
+              <button
+                onClick={() => {
+                  wishlist.forEach((product) => {
+                    if (
+                      !isInCart(product._id) &&
+                      product.availability === "In Stock"
+                    ) {
+                      cartMutation.mutate({
+                        productId: product._id,
+                        quantity: 1,
+                      });
+                    }
+                  });
+                }}
+                disabled={cartMutation.isPending}
+                className={`flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md w-full sm:w-auto ${
+                  cartMutation.isPending
+                    ? "bg-gray-400 cursor-not-allowed"
+                    : "bg-blue-600 hover:bg-blue-700 hover:shadow-lg"
+                }`}
+              >
+                <FaShoppingCart />
+                <span>Add All to Cart</span>
+              </button>
+              <button
+                onClick={() => {
                   if (
-                    !isInCart(product._id) &&
-                    product.availability === "In Stock"
-                  ) {
-                    cartMutation.mutate({
+                    !window.confirm(
+                      "Remove all items from your wishlist? This can't be undone."
+                    )
+                  )
+                    return;
+                  wishlist.forEach((product) => {
+                    wishlistMutation.mutate({
                       productId: product._id,
-                      quantity: 1,
+                      action: "remove",
                     });
-                  }
-                });
-              }}
-              disabled={cartMutation.isPending}
-              className={`flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md w-full sm:w-auto ${
-                cartMutation.isPending
-                  ? "bg-gray-400 cursor-not-allowed"
-                  : "bg-blue-600 hover:bg-blue-700 hover:shadow-lg"
-              }`}
-            >
-              <FaShoppingCart />
-              <span>Add All to Cart</span>
-            </button>
+                  });
+                }}
+                disabled={wishlistMutation.isPending}
+                className={`flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md w-full sm:w-auto ${
+                  wishlistMutation.isPending
+                    ? "bg-gray-400 cursor-not-allowed"
+                    : "bg-red-600 hover:bg-red-700 hover:shadow-lg"
+                }`}
+              >
+                <FaTrash />
+                <span>Clear All</span>
+              </button>
+            </div>
           )}
         </div>
 

--- a/components/ActiveLink.jsx
+++ b/components/ActiveLink.jsx
@@ -6,9 +6,9 @@ import { usePathname } from "next/navigation";
 const ActiveLink = ({ href, children, className = "" }) => {
   const pathname = usePathname();
   
-  const isActive = 
-    href === '/' 
-      ? pathname === '/' 
+  const isActive =
+    href === '/' || href === '/products'
+      ? pathname === href
       : pathname === href || pathname.startsWith(`${href}/`);
   
   const activeClass = isActive 

--- a/components/BestSellers.jsx
+++ b/components/BestSellers.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import Link from "next/link";
@@ -8,8 +8,8 @@ import { getBestSellers } from "@/actions/products";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import ProductCard from "./ProductCard";
-import { session } from "@/actions/auth-utils";
 
 const SkeletonProductCard = () => (
   <div className="bg-white shadow-md rounded-lg overflow-hidden h-[400px] w-full flex flex-col animate-pulse">
@@ -38,17 +38,8 @@ const SkeletonProductCard = () => (
 const BestSellers = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchUser() {
-      const res = await session();
-      if (res) {
-        setUser(res.user);
-      }
-    }
-    fetchUser();
-  }, []);
+  const { data: userSession } = useSession();
+  const user = userSession?.user;
 
   const { data: productsData, error: productsError, isLoading: productsLoading } = useQuery({
     queryKey: ["bestSellers"],

--- a/components/Deals.jsx
+++ b/components/Deals.jsx
@@ -1,14 +1,14 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import { getProducts } from "@/actions/products";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import ProductCard from "./ProductCard";
-import { session } from "@/actions/auth-utils";
 
 const SkeletonProductCard = () => (
   <div className="bg-white shadow-md rounded-lg overflow-hidden h-[400px] w-full flex flex-col animate-pulse">
@@ -37,17 +37,8 @@ const SkeletonProductCard = () => (
 const Deals = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchUser() {
-      const res = await session();
-      if (res) {
-        setUser(res.user);
-      }
-    }
-    fetchUser();
-  }, []);
+  const { data: userSession } = useSession();
+  const user = userSession?.user;
 
   const { data: productsData, error: productsError, isLoading: productsLoading } = useQuery({
     queryKey: ["deals"],

--- a/components/FeaturedProduct.jsx
+++ b/components/FeaturedProduct.jsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import Link from "next/link";
 import Image from "next/image";
 import { getProducts } from "@/actions/products";
 import { useRouter } from "next/navigation";
-import { session } from "@/actions/auth-utils";
+import { useSession } from "next-auth/react";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { getReviewsByProductId } from "@/actions/review-utils";
@@ -43,17 +43,8 @@ const FeaturedSkeleton = () => (
 const FeaturedProduct = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchUser() {
-      const res = await session();
-      if (res) {
-        setUser(res.user);
-      }
-    }
-    fetchUser();
-  }, []);
+  const { data: userSession } = useSession();
+  const user = userSession?.user;
 
   // Products data
   const {

--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -11,13 +11,13 @@ import { getCart } from "@/actions/cart-utils";
 import { getOrders } from "@/actions/order-utils";
 import { searchProducts } from "@/actions/products";
 import { useRouter } from "next/navigation";
-import { session } from "@/actions/auth-utils";
+import { useSession } from "next-auth/react";
 import { useDebounce } from "@/hooks/useDebounce";
 
 const Header = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [user, setUser] = useState(null);
+  const { data: user } = useSession();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
 
@@ -25,19 +25,6 @@ const Header = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-
-  useEffect(() => {
-    const fetchUserSession = async () => {
-      const sessionData = await session();
-      if (!sessionData) {
-        setUser(null);
-        return;
-      }
-      setUser(sessionData);
-    };
-
-    fetchUserSession();
-  }, []);
 
   useEffect(() => {
     setIsDropdownOpen(debouncedSearchTerm.length > 0);

--- a/components/ProductsCard.jsx
+++ b/components/ProductsCard.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import Image from "next/image";
@@ -10,21 +10,12 @@ import { getReviewsByProductId } from "@/actions/review-utils";
 import { updateWishlist } from "@/actions/wishlist";
 import { addToCart } from "@/actions/cart-utils";
 import { useRouter } from "next/navigation";
-import { session } from "@/actions/auth-utils";
+import { useSession } from "next-auth/react";
 
 const ProductCard = ({ product, wishlistData, cartData, queryClient }) => {
   const router = useRouter();
-  const [user, setUser] = useState(null);
-
-  useEffect(() => {
-    async function fetchUser() {
-      const res = await session();
-      if(res) {
-        setUser(res.user);
-      }
-    }
-    fetchUser();
-  }, [])
+  const { data: userSession } = useSession();
+  const user = userSession?.user;
 
   // Fetch reviews for this product
   const { data: reviewsData, error: reviewsError, isLoading: reviewsLoading } = useQuery({

--- a/components/Trending.jsx
+++ b/components/Trending.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "react-toastify";
 import Link from "next/link";
@@ -8,8 +8,8 @@ import { getProducts } from "@/actions/products";
 import { getWishlist, updateWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import ProductCard from "./ProductCard";
-import { session } from "@/actions/auth-utils";
 import LoadError from "@/components/LoadError";
 
 // Skeleton Loader for Product Cards
@@ -40,17 +40,8 @@ const SkeletonProductCard = () => (
 const Trending = () => {
   const queryClient = useQueryClient();
   const router = useRouter();
-  const [user, setUser] = useState(null);
-  
-    useEffect(() => {
-      async function fetchUser() {
-        const res = await session();
-        if(res) {
-          setUser(res.user);
-        }
-      }
-      fetchUser();
-    }, [])
+  const { data: userSession } = useSession();
+  const user = userSession?.user;
 
   // Fetch trending products (no dependency on user session)
   const { data: productsData, error: productsError, isLoading: productsLoading } = useQuery({


### PR DESCRIPTION
## Summary
- **Wishlist page**: 10 -> 12 items per page; added a "Clear All" button (with confirm) next to "Add All to Cart".
- **Products page**: price range filter's `$` sign was cramped against the Min/Max text — fixed spacing/padding.
- **False "please login" prompts**: clicking the wishlist/cart button while actually logged in intermittently redirected to `/login`. Root cause — `Header`, `Products`, `Trending`, `Deals`, `BestSellers`, `FeaturedProduct`, `ProductsCard`, `ProductDetails`, `cart/page.js`, and `wishlist/page.js` each tracked auth via their own `useState(null)` + `useEffect` calling a custom async `session()` server action. That's a fresh network round-trip per component instance, racing against the already-hydrated NextAuth client session — clicking soon after the page loads could catch `user` still `null`. Replaced with `useSession()` everywhere (the pattern already used correctly in `CategoryPage`, `SearchPage`, `RelatedProducts`), so auth state is read from the shared, already-resolved session context instead of triggering N redundant server round-trips.
- **Shop nav highlighting**: `ActiveLink` prefix-matched `/products/[id]` as part of `/products`, so "Shop" stayed highlighted on product detail pages. Now `/products` matches exactly, like `/`.

## Test plan
- [x] `/`, `/products`, `/cart`, `/wishlist` all compile and return 200 with no runtime error in the dev server
- [ ] Manually click wishlist/cart buttons on `/products`, PDP, and homepage sections right after page load while logged in — no false login prompt
- [ ] Confirm Shop nav item is not highlighted on a PDP
- [ ] Confirm wishlist shows 12 items/page and Clear All works