### PR TITLE
fix: replace window.confirm with popconfirm dialog; fix price range spacing

### DIFF
--- a/app/(shop)/products/Products.jsx
+++ b/app/(shop)/products/Products.jsx
@@ -434,7 +434,7 @@ const Products = ({ initialProducts }) => {
                   </label>
                   <div className="flex items-center space-x-2">
                     <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                      <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
                         <span className="text-gray-500 text-sm">$</span>
                       </div>
                       <input
@@ -443,14 +443,14 @@ const Products = ({ initialProducts }) => {
                         onChange={(e) =>
                           handlePriceRangeChange("min", e.target.value)
                         }
-                        className="block w-full pl-7 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
+                        className="block w-full pl-9 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
                         placeholder="Min"
                         min="0"
                       />
                     </div>
                     <span className="text-gray-500 text-sm">to</span>
                     <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                      <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
                         <span className="text-gray-500 text-sm">$</span>
                       </div>
                       <input
@@ -459,7 +459,7 @@ const Products = ({ initialProducts }) => {
                         onChange={(e) =>
                           handlePriceRangeChange("max", e.target.value)
                         }
-                        className="block w-full pl-7 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
+                        className="block w-full pl-9 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
                         placeholder="Max"
                         min="0"
                         max={maxProductPrice}

--- a/app/(shop)/wishlist/page.js
+++ b/app/(shop)/wishlist/page.js
@@ -19,6 +19,7 @@ import { addToCart, getCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import LoadError from "@/components/LoadError";
+import { useConfirm } from "@/hooks/useConfirm";
 
 // Skeleton Loader for Wishlist Items
 const SkeletonWishlistItem = () => (
@@ -41,6 +42,7 @@ const Wishlist = () => {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 12;
+  const [confirm, ConfirmationDialog] = useConfirm();
 
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -243,6 +245,7 @@ const Wishlist = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-100 via-blue-50 to-teal-50 py-8 px-4">
+      <ConfirmationDialog />
       {/* Main Content */}
       <div className="max-w-6xl mx-auto">
         <div className="bg-white/90 backdrop-blur-lg rounded-xl shadow-lg p-4 sm:p-6 mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 sm:gap-0">
@@ -287,13 +290,13 @@ const Wishlist = () => {
                 <span>Add All to Cart</span>
               </button>
               <button
-                onClick={() => {
-                  if (
-                    !window.confirm(
-                      "Remove all items from your wishlist? This can't be undone."
-                    )
-                  )
-                    return;
+                onClick={async () => {
+                  const ok = await confirm({
+                    title: "Clear wishlist?",
+                    message: "Remove all items from your wishlist? This can't be undone.",
+                    confirmText: "Clear All",
+                  });
+                  if (!ok) return;
                   wishlist.forEach((product) => {
                     wishlistMutation.mutate({
                       productId: product._id,

--- a/app/dashboard/products-list/page.js
+++ b/app/dashboard/products-list/page.js
@@ -13,6 +13,7 @@ import { getProducts, deleteProduct } from "@/actions/products";
 import { session } from "@/actions/auth-utils";
 import { Skeleton } from "@/components/skeletons";
 import { useDebounce } from "@/hooks/useDebounce";
+import { useConfirm } from "@/hooks/useConfirm";
 
 const ProductsPage = () => {
   const [visibleProducts, setVisibleProducts] = useState(10);
@@ -25,6 +26,7 @@ const ProductsPage = () => {
 
   const queryClient = useQueryClient();
   const router = useRouter();
+  const [confirm, ConfirmationDialog] = useConfirm();
 
   if(user && user?.user?.role !== "admin") {
     router.push('/');
@@ -97,8 +99,13 @@ const ProductsPage = () => {
 
   const handleShowMore = () => setVisibleProducts((prev) => prev + 10);
 
-  const handleDeleteProduct = (id) => {
-    if (window.confirm("Are you sure you want to delete this product?")) {
+  const handleDeleteProduct = async (id) => {
+    const ok = await confirm({
+      title: "Delete product?",
+      message: "Are you sure you want to delete this product? This can't be undone.",
+      confirmText: "Delete",
+    });
+    if (ok) {
       deleteProductMutation.mutate(id);
     }
   };
@@ -144,6 +151,7 @@ const ProductsPage = () => {
 
   return (
     <div className="container mx-auto px-4 py-8 mb-12 sm:mb-0">
+      <ConfirmationDialog />
       <div className="flex flex-col sm:flex-row justify-between items-center mb-6 gap-4">
         <h1 className="text-2xl sm:text-3xl font-bold">Product List</h1>
         <Link

--- a/components/ConfirmDialog.jsx
+++ b/components/ConfirmDialog.jsx
@@ -1,0 +1,55 @@
+"use client";
+
+import React from "react";
+
+const ConfirmDialog = ({
+  open,
+  title = "Are you sure?",
+  message,
+  confirmText = "OK",
+  cancelText = "Cancel",
+  danger = true,
+  onConfirm,
+  onCancel,
+}) => {
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 p-4"
+      onClick={onCancel}
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="confirm-dialog-title" className="text-lg font-semibold text-gray-800">
+          {title}
+        </h2>
+        {message && <p className="mt-2 text-sm text-gray-600">{message}</p>}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 transition"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={onConfirm}
+            autoFocus
+            className={`px-4 py-2 rounded-lg font-medium text-white transition ${
+              danger ? "bg-red-600 hover:bg-red-700" : "bg-primary hover:bg-gray-800"
+            }`}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/hooks/useConfirm.js
+++ b/hooks/useConfirm.js
@@ -1,0 +1,37 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import ConfirmDialog from "@/components/ConfirmDialog";
+
+// Promise-based replacement for window.confirm().
+// const [confirm, ConfirmationDialog] = useConfirm();
+// const ok = await confirm({ title, message });
+// Render <ConfirmationDialog /> once anywhere in the component tree.
+export function useConfirm() {
+  const [options, setOptions] = useState(null);
+  const resolveRef = useRef(null);
+
+  const confirm = useCallback((options = {}) => {
+    return new Promise((resolve) => {
+      resolveRef.current = resolve;
+      setOptions(options);
+    });
+  }, []);
+
+  const respond = (result) => {
+    resolveRef.current?.(result);
+    resolveRef.current = null;
+    setOptions(null);
+  };
+
+  const ConfirmationDialog = () => (
+    <ConfirmDialog
+      open={!!options}
+      {...options}
+      onConfirm={() => respond(true)}
+      onCancel={() => respond(false)}
+    />
+  );
+
+  return [confirm, ConfirmationDialog];
+}


### PR DESCRIPTION
## Summary
- Native browser `window.confirm()` alert replaced with a reusable, styled in-app confirm dialog: `components/ConfirmDialog.jsx` + `hooks/useConfirm.js` (promise-based, `const ok = await confirm({title, message})`).
- Wired into the two existing confirm spots: wishlist "Clear All" and admin product delete.
- Products page price range filter: `$` sign was still visually cramped against "Min"/"Max" placeholder text — widened the gap (icon `pl-4`, input `pl-9`).

## Test plan
- [x] `/products` and `/wishlist` compile clean, no runtime errors
- [ ] Manually trigger wishlist "Clear All" — styled dialog appears instead of browser alert, Cancel/OK both work
- [ ] Manually trigger admin product delete — same
- [ ] Visually confirm Min/Max price inputs have clear spacing from `$`