### PR TITLE
fix: price range $ sign overlapping Min/Max placeholder

### DIFF
--- a/app/(shop)/products/Products.jsx
+++ b/app/(shop)/products/Products.jsx
@@ -433,38 +433,28 @@ const Products = ({ initialProducts }) => {
                     Price Range
                   </label>
                   <div className="flex items-center space-x-2">
-                    <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-                        <span className="text-gray-500 text-sm">$</span>
-                      </div>
-                      <input
-                        type="number"
-                        value={priceRange.min}
-                        onChange={(e) =>
-                          handlePriceRangeChange("min", e.target.value)
-                        }
-                        className="block w-full pl-9 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
-                        placeholder="Min"
-                        min="0"
-                      />
-                    </div>
+                    <input
+                      type="number"
+                      value={priceRange.min}
+                      onChange={(e) =>
+                        handlePriceRangeChange("min", e.target.value)
+                      }
+                      className="block w-full flex-1 px-3 py-2 text-sm border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
+                      placeholder="$ Min"
+                      min="0"
+                    />
                     <span className="text-gray-500 text-sm">to</span>
-                    <div className="relative rounded-md shadow-sm flex-1">
-                      <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-                        <span className="text-gray-500 text-sm">$</span>
-                      </div>
-                      <input
-                        type="number"
-                        value={priceRange.max}
-                        onChange={(e) =>
-                          handlePriceRangeChange("max", e.target.value)
-                        }
-                        className="block w-full pl-9 pr-2 py-2 text-sm border border-gray-300 rounded-md focus:ring-primary focus:border-primary"
-                        placeholder="Max"
-                        min="0"
-                        max={maxProductPrice}
-                      />
-                    </div>
+                    <input
+                      type="number"
+                      value={priceRange.max}
+                      onChange={(e) =>
+                        handlePriceRangeChange("max", e.target.value)
+                      }
+                      className="block w-full flex-1 px-3 py-2 text-sm border border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
+                      placeholder="$ Max"
+                      min="0"
+                      max={maxProductPrice}
+                    />
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
The `$` sign in the price range filter was an absolutely-positioned overlay occupying the same horizontal space as the input's placeholder text, so the two collided and rendered as "$in"/"$ax". Earlier padding adjustments couldn't reliably separate two overlapping text layers.

Fix: removed the `$` overlay entirely and baked it into the placeholder (`$ Min` / `$ Max`). Single text layer — overlap is now impossible.

## Test plan
- [x] `/products` compiles clean, returns 200
- [ ] Visually confirm placeholders read "$ Min" / "$ Max" with no overlap