### PR TITLE
fix: Clear All wishlist race causing "Failed to update wishlist"

### DIFF
--- a/actions/wishlist/index.js
+++ b/actions/wishlist/index.js
@@ -16,6 +16,22 @@ export const getWishlist = async () => {
   }
 };
 
+// Clear the entire wishlist in a single atomic request
+export const clearWishlist = async () => {
+  try {
+    const response = await api.delete("/wishlist", {
+      headers: {
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        Pragma: "no-cache",
+        Expires: "0",
+      },
+    });
+    return response.data;
+  } catch (error) {
+    throw new Error(error.response?.data?.error || "Failed to clear wishlist");
+  }
+};
+
 // Add or remove a product from the wishlist
 export const updateWishlist = async (productId, action) => {
   try {

--- a/app/(shop)/wishlist/page.js
+++ b/app/(shop)/wishlist/page.js
@@ -14,7 +14,7 @@ import {
   FaSpinner,
   FaShoppingBag,
 } from "react-icons/fa";
-import { getWishlist, updateWishlist } from "@/actions/wishlist";
+import { getWishlist, updateWishlist, clearWishlist } from "@/actions/wishlist";
 import { addToCart, getCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
@@ -71,6 +71,34 @@ const Wishlist = () => {
   // Mutation to remove item from wishlist
   const wishlistMutation = useMutation({
     mutationFn: ({ productId, action }) => updateWishlist(productId, action),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(["wishlist"]);
+      toast.success(data.message, {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to manage your wishlist.", {
+          position: "top-right",
+          autoClose: 3000,
+        });
+        setTimeout(() => {
+          router.push("/login");
+        }, 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, {
+          position: "top-right",
+          autoClose: 3000,
+        });
+      }
+    },
+  });
+
+  // Mutation to clear the whole wishlist in one request
+  const clearWishlistMutation = useMutation({
+    mutationFn: clearWishlist,
     onSuccess: (data) => {
       queryClient.invalidateQueries(["wishlist"]);
       toast.success(data.message, {
@@ -297,16 +325,11 @@ const Wishlist = () => {
                     confirmText: "Clear All",
                   });
                   if (!ok) return;
-                  wishlist.forEach((product) => {
-                    wishlistMutation.mutate({
-                      productId: product._id,
-                      action: "remove",
-                    });
-                  });
+                  clearWishlistMutation.mutate();
                 }}
-                disabled={wishlistMutation.isPending}
+                disabled={clearWishlistMutation.isPending}
                 className={`flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md w-full sm:w-auto ${
-                  wishlistMutation.isPending
+                  clearWishlistMutation.isPending
                     ? "bg-gray-400 cursor-not-allowed"
                     : "bg-red-600 hover:bg-red-700 hover:shadow-lg"
                 }`}

--- a/app/api/wishlist/route.js
+++ b/app/api/wishlist/route.js
@@ -111,3 +111,38 @@ export async function POST(req) {
     );
   }
 }
+
+export async function DELETE(req) {
+  await dbConnect();
+
+  try {
+    const userSession = await session();
+    if (!userSession || !userSession.user) {
+      return NextResponse.json(
+        { error: "Unauthorized. Please log in." },
+        { status: 401 }
+      );
+    }
+
+    const userId = userSession.user.id;
+
+    // Atomic single-write clear instead of N concurrent remove requests,
+    // which race on the wishlist doc's version key and fail all but one.
+    const wishlist = await Wishlist.findOneAndUpdate(
+      { user: userId },
+      { $set: { products: [] } },
+      { new: true, upsert: true }
+    );
+
+    return NextResponse.json(
+      { message: "Wishlist cleared", wishlist: wishlist.products },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Error clearing wishlist:", error);
+    return NextResponse.json(
+      { error: "Failed to clear wishlist" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
"Clear All" on `/wishlist` fired one `mutate()` per item, all concurrently hitting the same read-modify-write `POST /api/wishlist` endpoint (find doc → filter one product out → save). Mongoose's version key makes concurrent saves on the same document race: whichever request's `save()` lands first wins, the rest hit a version conflict and fall into the generic catch as a 500 `{"error": "Failed to update wishlist"}` — visible in prod as one success toast plus N-1 error toasts, and the wishlist left non-empty.

## Fix
- Added `DELETE /api/wishlist` — clears the whole wishlist in a single atomic `findOneAndUpdate`, no read-then-write race.
- Added `clearWishlist()` client action and a dedicated `clearWishlistMutation`.
- "Clear All" button now fires one request instead of N concurrent ones.

## Test plan
- [x] `/wishlist` compiles clean
- [x] `DELETE /api/wishlist` returns 401 when unauthenticated (route wired correctly)
- [ ] Manually: add 3+ items to wishlist, click Clear All, confirm — single success toast, wishlist ends up empty, no error toasts