### PR TITLE
fix: 6 critical security findings from audit

### DIFF
--- a/actions/contact/index.js
+++ b/actions/contact/index.js
@@ -1,11 +1,11 @@
 import api from "@/lib/axios";
 
-export async function sendEmail({ to, subject, html }) {
+export async function sendEmail({ name, email, subject, message }) {
     try {
-      const response = await api.post(`/send-email`, { to, subject, html });
-      return response.data; 
+      const response = await api.post(`/send-email`, { name, email, subject, message });
+      return response.data;
     } catch (error) {
       console.error("Error in sendEmail action:", error);
-      throw error; 
+      throw error;
     }
   }

--- a/app/(shop)/contact/ContactUs.jsx
+++ b/app/(shop)/contact/ContactUs.jsx
@@ -26,24 +26,12 @@ const ContactUs = () => {
     setIsSubmitting(true);
     setSubmitStatus(null);
 
-    const htmlContent = `
-      <div style="font-family: Arial, sans-serif; padding: 20px; background-color: #f9f9f9;">
-        <h2 style="color: #333;">New Contact Form Submission</h2>
-        <p><strong>Name:</strong> ${formData.name}</p>
-        <p><strong>Email:</strong> ${formData.email}</p>
-        <p><strong>Subject:</strong> ${formData.subject}</p>
-        <p><strong>Message:</strong></p>
-        <p style="white-space: pre-wrap;">${formData.message}</p>
-        <hr style="border: 0; border-top: 1px solid #ddd; margin: 20px 0;">
-        <p style="color: #777; font-size: 12px;">This email was sent from the SwiftCart Contact Us page.</p>
-      </div>
-    `;
-
     try {
       const result = await sendEmail({
-        to: "aihridoy976@gmail.com",
-        subject: `Contact Form: ${formData.subject}`,
-        html: htmlContent,
+        name: formData.name,
+        email: formData.email,
+        subject: formData.subject,
+        message: formData.message,
       });
 
       if (result.success) {

--- a/app/(shop)/unsubscribe/page.js
+++ b/app/(shop)/unsubscribe/page.js
@@ -1,14 +1,49 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
-const UnsubscribePage = () => {
+function UnsubscribeContent() {
+  const searchParams = useSearchParams();
+  const tokenEmail = searchParams.get("email");
+  const token = searchParams.get("token");
+
   const [email, setEmail] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
 
-  const handleSubmit = async (e) => {
+  // Clicked an unsubscribe link from an email - complete it automatically.
+  useEffect(() => {
+    if (!tokenEmail || !token) return;
+
+    const run = async () => {
+      setIsSubmitting(true);
+      try {
+        const res = await fetch("/api/newsletter", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: tokenEmail, token }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.success) {
+          setError(data.error || "Something went wrong. Please try again.");
+        } else {
+          setSuccess("You've been unsubscribed. Sorry to see you go!");
+        }
+      } catch {
+        setError("Something went wrong. Please try again.");
+      } finally {
+        setIsSubmitting(false);
+      }
+    };
+    run();
+  }, [tokenEmail, token]);
+
+  // No link, just a manual visit - request a fresh unsubscribe link by
+  // email rather than unsubscribing directly, so this can't be used to
+  // remove someone else's address without proving ownership.
+  const handleRequestLink = async (e) => {
     e.preventDefault();
     setError("");
     setSuccess("");
@@ -16,7 +51,7 @@ const UnsubscribePage = () => {
 
     try {
       const res = await fetch("/api/newsletter", {
-        method: "DELETE",
+        method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
       });
@@ -24,18 +59,29 @@ const UnsubscribePage = () => {
 
       if (!res.ok || !data.success) {
         setError(data.error || "Something went wrong. Please try again.");
-        setIsSubmitting(false);
-        return;
+      } else {
+        setSuccess(data.message);
+        setEmail("");
       }
-
-      setSuccess("You've been unsubscribed. Sorry to see you go!");
-      setEmail("");
-      setIsSubmitting(false);
-    } catch (err) {
+    } catch {
       setError("Something went wrong. Please try again.");
+    } finally {
       setIsSubmitting(false);
     }
   };
+
+  if (tokenEmail && token) {
+    return (
+      <section className="mx-auto max-w-lg px-4 py-20 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">
+          Unsubscribe
+        </h1>
+        {isSubmitting && <p className="text-gray-600">Processing...</p>}
+        {error && <p className="text-red-600">{error}</p>}
+        {success && <p className="text-green-600">{success}</p>}
+      </section>
+    );
+  }
 
   return (
     <section className="mx-auto max-w-lg px-4 py-20">
@@ -43,11 +89,11 @@ const UnsubscribePage = () => {
         Unsubscribe from our newsletter
       </h1>
       <p className="text-gray-600 mb-8">
-        Enter the email address you subscribed with, and we&apos;ll remove it
-        from our list.
+        Enter the email address you subscribed with, and we&apos;ll send you a
+        link to unsubscribe.
       </p>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
+      <form onSubmit={handleRequestLink} className="space-y-4">
         <input
           type="email"
           required
@@ -69,7 +115,7 @@ const UnsubscribePage = () => {
           disabled={isSubmitting}
           className="w-full px-6 py-3 bg-red-600 hover:bg-red-700 text-white font-semibold rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isSubmitting ? "Unsubscribing..." : "Unsubscribe"}
+          {isSubmitting ? "Sending..." : "Send unsubscribe link"}
         </button>
 
         {error && <p className="text-red-600 text-sm">{error}</p>}
@@ -77,6 +123,12 @@ const UnsubscribePage = () => {
       </form>
     </section>
   );
-};
+}
 
-export default UnsubscribePage;
+export default function UnsubscribePage() {
+  return (
+    <Suspense fallback={null}>
+      <UnsubscribeContent />
+    </Suspense>
+  );
+}

--- a/app/api/newsletter/route.js
+++ b/app/api/newsletter/route.js
@@ -1,8 +1,15 @@
 import { Resend } from "resend";
+import crypto from "crypto";
 import { dbConnect } from "@/service/mongo";
 import { Newsletter } from "@/models/newsletter-model";
+import { rateLimit, clientIp } from "@/service/rate-limit";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
+
+function unsubscribeLink(email, token) {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+    return `${base}/unsubscribe?email=${encodeURIComponent(email)}&token=${token}`;
+}
 
 export const POST = async (req) => {
     try {
@@ -25,7 +32,8 @@ export const POST = async (req) => {
             );
         }
 
-        await Newsletter.create({ email });
+        const unsubscribeToken = crypto.randomBytes(32).toString("hex");
+        await Newsletter.create({ email, unsubscribeToken });
 
         await resend.emails.send({
             from: "SwiftCart <noreply@ashrafulislam.im>",
@@ -36,7 +44,7 @@ export const POST = async (req) => {
                 <h2 style="color: #333;">Welcome to SwiftCart!</h2>
                 <p>Thanks for subscribing. You'll now get exclusive offers, new arrivals & home decor inspiration delivered to your inbox weekly.</p>
                 <hr style="border: 0; border-top: 1px solid #ddd; margin: 20px 0;">
-                <p style="color: #777; font-size: 12px;">This email was sent from SwiftCart.</p>
+                <p style="color: #777; font-size: 12px;">This email was sent from SwiftCart. <a href="${unsubscribeLink(email, unsubscribeToken)}">Unsubscribe</a></p>
               </div>
             `,
         });
@@ -54,26 +62,43 @@ export const POST = async (req) => {
     }
 };
 
+// Unsubscribing requires the token mailed to that address at subscribe
+// time - accepting a bare email here let anyone mass-unsubscribe addresses
+// they don't own. Callers without a token should hit PATCH first to have
+// one emailed to them.
 export const DELETE = async (req) => {
     try {
-        const { email } = await req.json();
-
-        if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        const { allowed, retryAfterSeconds } = rateLimit(`unsubscribe:${clientIp(req)}`, {
+            limit: 10,
+            windowMs: 10 * 60 * 1000,
+        });
+        if (!allowed) {
             return new Response(
-                JSON.stringify({ success: false, error: "Please enter a valid email address" }),
+                JSON.stringify({ success: false, error: "Too many attempts. Please try again later." }),
+                { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(retryAfterSeconds) } }
+            );
+        }
+
+        const { email, token } = await req.json();
+
+        if (!email || !token || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            return new Response(
+                JSON.stringify({ success: false, error: "A valid email and unsubscribe token are required" }),
                 { status: 400, headers: { "Content-Type": "application/json" } }
             );
         }
 
         await dbConnect();
 
-        const deleted = await Newsletter.findOneAndDelete({ email: email.toLowerCase() });
-        if (!deleted) {
+        const subscriber = await Newsletter.findOne({ email: email.toLowerCase() });
+        if (!subscriber || subscriber.unsubscribeToken !== token) {
             return new Response(
-                JSON.stringify({ success: false, error: "This email is not subscribed" }),
-                { status: 404, headers: { "Content-Type": "application/json" } }
+                JSON.stringify({ success: false, error: "Invalid or expired unsubscribe link" }),
+                { status: 401, headers: { "Content-Type": "application/json" } }
             );
         }
+
+        await Newsletter.deleteOne({ _id: subscriber._id });
 
         return new Response(
             JSON.stringify({ success: true, message: "Unsubscribed successfully" }),
@@ -81,6 +106,57 @@ export const DELETE = async (req) => {
         );
     } catch (error) {
         console.error("Error in newsletter DELETE API:", error);
+        return new Response(
+            JSON.stringify({ success: false, error: "Something went wrong. Please try again." }),
+            { status: 500, headers: { "Content-Type": "application/json" } }
+        );
+    }
+};
+
+// Request a fresh unsubscribe link by email (used by the manual-entry form
+// when the caller doesn't have a link handy). Always responds the same way
+// regardless of whether the email is subscribed, so this can't be used to
+// probe the subscriber list.
+export const PATCH = async (req) => {
+    try {
+        const { allowed, retryAfterSeconds } = rateLimit(`unsubscribe-request:${clientIp(req)}`, {
+            limit: 5,
+            windowMs: 10 * 60 * 1000,
+        });
+        if (!allowed) {
+            return new Response(
+                JSON.stringify({ success: false, error: "Too many attempts. Please try again later." }),
+                { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(retryAfterSeconds) } }
+            );
+        }
+
+        const { email } = await req.json();
+        const generic = { success: true, message: "If that email is subscribed, we've sent an unsubscribe link." };
+
+        if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+            return new Response(JSON.stringify(generic), { status: 200, headers: { "Content-Type": "application/json" } });
+        }
+
+        await dbConnect();
+        const subscriber = await Newsletter.findOne({ email: email.toLowerCase() });
+
+        if (subscriber) {
+            await resend.emails.send({
+                from: "SwiftCart <noreply@ashrafulislam.im>",
+                to: subscriber.email,
+                subject: "Your SwiftCart unsubscribe link",
+                html: `
+                  <div style="font-family: Arial, sans-serif; padding: 20px; background-color: #f9f9f9;">
+                    <p>Click below to unsubscribe from the SwiftCart newsletter:</p>
+                    <p><a href="${unsubscribeLink(subscriber.email, subscriber.unsubscribeToken)}">Unsubscribe</a></p>
+                  </div>
+                `,
+            });
+        }
+
+        return new Response(JSON.stringify(generic), { status: 200, headers: { "Content-Type": "application/json" } });
+    } catch (error) {
+        console.error("Error in newsletter PATCH API:", error);
         return new Response(
             JSON.stringify({ success: false, error: "Something went wrong. Please try again." }),
             { status: 500, headers: { "Content-Type": "application/json" } }

--- a/app/api/products/[id]/increment-popularity/route.js
+++ b/app/api/products/[id]/increment-popularity/route.js
@@ -2,22 +2,38 @@
 import { Product } from "@/models/product-model";
 import { dbConnect } from "@/service/mongo";
 import { NextResponse } from "next/server";
+import { rateLimit, clientIp } from "@/service/rate-limit";
 
 export async function POST(req, { params }) {
   await dbConnect();
 
   try {
     const { id } = params;
-    const { incrementBy = 1 } = await req.json();
 
-    const product = await Product.findById(id);
+    // Anonymous view-count ping, no session required by design - but the
+    // increment amount must never come from the client, or anyone can call
+    // this in a loop to inflate rankings arbitrarily. Always +1, rate
+    // limited per IP+product so repeated page loads can't be scripted.
+    const { allowed, retryAfterSeconds } = rateLimit(`popularity:${clientIp(req)}:${id}`, {
+      limit: 10,
+      windowMs: 60 * 1000,
+    });
+    if (!allowed) {
+      return NextResponse.json(
+        { error: "Too many requests" },
+        { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } }
+      );
+    }
+
+    const product = await Product.findByIdAndUpdate(
+      id,
+      { $inc: { popularityScore: 1 } },
+      { new: true }
+    );
 
     if (!product) {
       return NextResponse.json({ error: "Product not found" }, { status: 404 });
     }
-
-    product.popularityScore = (product.popularityScore || 0) + incrementBy;
-    await product.save();
 
     return NextResponse.json(
       {
@@ -30,38 +46,6 @@ export async function POST(req, { params }) {
     console.error("Error incrementing popularity:", error);
     return NextResponse.json(
       { error: "Failed to increment popularity" },
-      { status: 500 }
-    );
-  }
-}
-
-export async function DELETE(req, { params }) {
-  await dbConnect();
-
-  try {
-    const { id } = params;
-
-    if (!id) {
-      return NextResponse.json(
-        { error: "Product ID is required" },
-        { status: 400 }
-      );
-    }
-
-    const deleteProduct = await Product.findByIdAndDelete(id);
-
-    if (!deleteProduct) {
-      return NextResponse.json({ error: "Product not found" }, { status: 404 });
-    }
-
-    return NextResponse.json(
-      { message: "Product deleted successfully" },
-      { status: 200 }
-    );
-  } catch (error) {
-    console.error("Error deleting product:", error);
-    return NextResponse.json(
-      { error: "Failed to delete product" },
       { status: 500 }
     );
   }

--- a/app/api/register/route.js
+++ b/app/api/register/route.js
@@ -19,10 +19,10 @@ export async function POST(req) {
 
     await dbConnect();
 
-    const { name, email, password, role } = await req.json();
+    const { name, email, password } = await req.json();
 
     // Validate input
-    if (!name || !email || !password || !role) {
+    if (!name || !email || !password) {
       return NextResponse.json(
         { message: "Name, email, and password are required" },
         { status: 400 }
@@ -59,12 +59,14 @@ export async function POST(req) {
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
 
-    // Create new user
+    // role is never accepted from the client - every self-registration is
+    // a plain "user" account (schema enum: user|admin). Admin accounts are
+    // provisioned separately, not through open registration.
     const newUser = await User.create({
       name,
       email,
       password: hashedPassword,
-      role
+      role: "user",
     });
 
     return NextResponse.json(

--- a/app/api/send-email/route.js
+++ b/app/api/send-email/route.js
@@ -1,16 +1,64 @@
 import { Resend } from "resend";
+import { rateLimit, clientIp } from "@/service/rate-limit";
 
 const resend = new Resend(process.env.RESEND_API_KEY);
+const CONTACT_EMAIL = process.env.CONTACT_EMAIL || "aihridoy976@gmail.com";
+
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
 
 export const POST = async (req) => {
     try {
+        const { allowed, retryAfterSeconds } = rateLimit(`send-email:${clientIp(req)}`, {
+            limit: 5,
+            windowMs: 10 * 60 * 1000,
+        });
+        if (!allowed) {
+            return new Response(
+                JSON.stringify({ success: false, error: "Too many messages sent. Please try again later." }),
+                { status: 429, headers: { "Content-Type": "application/json", "Retry-After": String(retryAfterSeconds) } }
+            );
+        }
+
         const body = await req.json();
-        const { to, subject, html } = body;
+        const { name, email, subject, message } = body;
+
+        // `to` and `html` are never taken from the client - accepting them
+        // directly turned this into an open relay (arbitrary destination,
+        // arbitrary HTML) using this site's Resend account. Only structured
+        // contact-form fields are accepted; the email itself is built here.
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!name || !email || !subject || !message || !emailRegex.test(email)) {
+            return new Response(
+                JSON.stringify({ success: false, error: "Name, a valid email, subject, and message are required" }),
+                { status: 400, headers: { "Content-Type": "application/json" } }
+            );
+        }
+
+        const html = `
+      <div style="font-family: Arial, sans-serif; padding: 20px; background-color: #f9f9f9;">
+        <h2 style="color: #333;">New Contact Form Submission</h2>
+        <p><strong>Name:</strong> ${escapeHtml(name)}</p>
+        <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+        <p><strong>Subject:</strong> ${escapeHtml(subject)}</p>
+        <p><strong>Message:</strong></p>
+        <p style="white-space: pre-wrap;">${escapeHtml(message)}</p>
+        <hr style="border: 0; border-top: 1px solid #ddd; margin: 20px 0;">
+        <p style="color: #777; font-size: 12px;">This email was sent from the SwiftCart Contact Us page.</p>
+      </div>
+    `;
 
         const emailResponse = await resend.emails.send({
             from: "SwiftCart <noreply@ashrafulislam.im>",
-            to,
-            subject,
+            to: CONTACT_EMAIL,
+            replyTo: email,
+            subject: `Contact Form: ${subject}`,
             html,
         });
 
@@ -33,7 +81,7 @@ export const POST = async (req) => {
     } catch (error) {
         console.error("Error sending email:", error);
         return new Response(
-            JSON.stringify({ success: false, error: error.message }),
+            JSON.stringify({ success: false, error: "Failed to send message" }),
             { status: 500, headers: { "Content-Type": "application/json" } }
         );
     }

--- a/models/newsletter-model.js
+++ b/models/newsletter-model.js
@@ -8,6 +8,10 @@ const newsletterSchema = new Schema({
         lowercase: true,
         trim: true,
     },
+    unsubscribeToken: {
+        type: String,
+        required: true,
+    },
 }, { timestamps: true });
 
 export const Newsletter = mongoose.models.newsletters ?? mongoose.model("newsletters", newsletterSchema);

--- a/providers/ReactQueryProvider.js
+++ b/providers/ReactQueryProvider.js
@@ -1,34 +1,43 @@
 'use client';
 
+import { useState } from 'react';
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { toast } from 'react-toastify';
 
-// react-query v5 dropped per-query onError callbacks, so the app's failure
-// toasts were dead code. One cache-level handler covers every query instead.
-const queryCache = new QueryCache({
-  onError: (error) => {
-    if (error?.message?.includes('Unauthorized')) return; // middleware handles this
-    toast.error(error?.message || 'Something went wrong. Please try again.', {
-      position: 'top-right',
-      autoClose: 3000,
-      toastId: error?.message,
-    });
-  },
-});
-
-const queryClient = new QueryClient({
-  queryCache,
-  defaultOptions: {
-    queries: {
-      staleTime: 30 * 1000,
-      retry: 2,
-      refetchOnWindowFocus: false,
+function createQueryClient() {
+  // react-query v5 dropped per-query onError callbacks, so the app's failure
+  // toasts were dead code. One cache-level handler covers every query instead.
+  const queryCache = new QueryCache({
+    onError: (error) => {
+      if (error?.message?.includes('Unauthorized')) return; // middleware handles this
+      toast.error(error?.message || 'Something went wrong. Please try again.', {
+        position: 'top-right',
+        autoClose: 3000,
+        toastId: error?.message,
+      });
     },
-  },
-});
+  });
+
+  return new QueryClient({
+    queryCache,
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000,
+        retry: 2,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
 
 export default function ReactQueryProvider({ children }) {
+  // Module-scope singleton would be shared across every concurrent SSR
+  // request in the same server process - fine today (no dehydrate/prefetch
+  // reads into it yet) but a landmine the moment someone adds one. Lazy
+  // useState gives each component tree its own client, created once.
+  const [queryClient] = useState(createQueryClient);
+
   return (
     <QueryClientProvider client={queryClient}>
       {children}


### PR DESCRIPTION
## Summary
An audit (run via a secondary tool, Mimo Code) flagged 6 critical vulnerabilities. Each was independently verified against actual behavior before fixing - two of the audit's implied fixes would have broken working functionality, so those were implemented differently (noted below).

- **Unauthenticated product deletion** (`DELETE /api/products/[id]/increment-popularity`) - had zero auth and turned out to be entirely unused dead code (the real delete flow already goes through the properly authenticated `/api/products/[id]` DELETE). Removed the handler instead of adding auth to unused code.
- **Registration privilege escalation** - `role` came straight from the request body, so `{role: "admin"}` created an admin account. Server now always stores `role: "user"`.
- **Popularity score manipulation** - `incrementBy` was client-controlled with no bounds. This endpoint is meant to be called anonymously on every product view (that's the point), so requiring auth would break it - instead the server always increments by exactly 1 and rate-limits per IP+product.
- **Open email relay** (`/api/send-email`) - `to`/`html` came directly from the client, letting anyone send arbitrary HTML to arbitrary addresses via this site's Resend account. Now only accepts structured contact-form fields, builds the HTML server-side with escaping, sends only to a fixed destination, and is rate-limited.
- **Mass newsletter unsubscribe** - any email could be unsubscribed with no proof of ownership. Added a per-subscriber `unsubscribeToken` (mirrors the existing reset-password token pattern), mailed in the welcome email; unsubscribing now requires a matching token. Added a `PATCH` endpoint to request a fresh link (generic response either way, no enumeration).
- **QueryClient SSR singleton** - module-scope instantiation would leak cached data across concurrent SSR requests the moment anything adds `dehydrate`/`HydrationBoundary` (nothing does yet, but it's the standard safe pattern and costs nothing). Moved to lazy `useState` per Next.js's official App Router guidance.

## Test plan
All verified live against the dev server:
- [x] `DELETE /api/products/[id]/increment-popularity` -> 405
- [x] `incrementBy: 999999` -> score moves by exactly 1
- [x] `role: "admin"` in register body -> stored as `"user"`
- [x] Old `{to, html}` payload to `/api/send-email` -> 400
- [x] Unsubscribe without a token -> 400
- [x] Subscribe + request-link flow returns identical generic response for subscribed and non-subscribed emails
- [x] `/`, `/register`, `/contact`, `/unsubscribe`, `/products` all compile clean