### PR TITLE
fix: medium-severity findings from audit

### DIFF
--- a/app/(shop)/layout.js
+++ b/app/(shop)/layout.js
@@ -1,4 +1,3 @@
-import "react-toastify/dist/ReactToastify.css";
 import Navbar from "@/components/Navbar";
 import Header from "@/components/Header";
 import ClientLayout from "../ClientLayout";

--- a/app/(shop)/page.js
+++ b/app/(shop)/page.js
@@ -1,15 +1,21 @@
-import Ads from "@/components/Ads";
+import dynamic from "next/dynamic";
 import Banner from "@/components/Banner";
-import BestSellers from "@/components/BestSellers";
-import Deals from "@/components/Deals";
-import FAQHome from "@/components/FAQHome";
-import FeaturedProduct from "@/components/FeaturedProduct";
 import Features from "@/components/Features";
-import NewArrival from "@/components/NewArrival";
-import NewsLetter from "@/components/NewsLetter";
 import ShopByCategory from "@/components/ShopByCategory";
-import Testimonials from "@/components/Testimonials";
-import Trending from "@/components/Trending";
+import NewArrival from "@/components/NewArrival";
+import BestSellers from "@/components/BestSellers";
+import FeaturedProduct from "@/components/FeaturedProduct";
+
+// Below-the-fold sections split into their own chunks instead of bundled
+// with the above-the-fold ones. `ssr: false` isn't usable here (this page
+// is a Server Component - Next.js only allows it from a Client Component),
+// so this only trims initial bundle size, not time-to-first-byte.
+const Deals = dynamic(() => import("@/components/Deals"));
+const Ads = dynamic(() => import("@/components/Ads"));
+const Trending = dynamic(() => import("@/components/Trending"));
+const Testimonials = dynamic(() => import("@/components/Testimonials"));
+const FAQHome = dynamic(() => import("@/components/FAQHome"));
+const NewsLetter = dynamic(() => import("@/components/NewsLetter"));
 
 export const metadata = {
   title: "Home Decor, Furniture & Lifestyle Products",

--- a/app/(shop)/search/page.js
+++ b/app/(shop)/search/page.js
@@ -1,4 +1,5 @@
 import SearchPage from "./SearchPage";
+import { Suspense } from "react";
 
 export const metadata = {
   title: "Search",
@@ -6,5 +7,9 @@ export const metadata = {
 };
 
 export default function Page() {
-  return <SearchPage />;
+  return (
+    <Suspense fallback={null}>
+      <SearchPage />
+    </Suspense>
+  );
 }

--- a/app/api/cart/route.js
+++ b/app/api/cart/route.js
@@ -16,6 +16,13 @@ export async function POST(request) {
 
     const { productId, quantity = 1 } = await request.json();
 
+    if (!Number.isInteger(quantity) || quantity < 1) {
+      return NextResponse.json(
+        { error: "Quantity must be a positive integer" },
+        { status: 400 }
+      );
+    }
+
     // Validate product
     const product = await Product.findById(productId);
     if (!product) {

--- a/app/dashboard/page.js
+++ b/app/dashboard/page.js
@@ -17,21 +17,22 @@ import {
   FiEye,
   FiAlertTriangle,
 } from "react-icons/fi";
-import { Bar, Pie } from "react-chartjs-2";
-import {
-  Chart as ChartJS,
-  CategoryScale,
-  LinearScale,
-  BarElement,
-  ArcElement,
-  Title,
-  Tooltip,
-  Legend,
-} from "chart.js";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import { Skeleton } from "@/components/skeletons";
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
+// chart.js + react-chartjs-2 is ~200KB+ that this page doesn't need until
+// after the stats/data above have rendered - load it only on the client,
+// only when this page is actually visited.
+const DashboardCharts = dynamic(() => import("@/components/DashboardCharts"), {
+  ssr: false,
+  loading: () => (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+      <Skeleton className="h-72 w-full rounded-xl" />
+      <Skeleton className="h-72 w-full rounded-xl" />
+    </div>
+  ),
+});
 
 const STATUS_STYLES = {
   Pending: "bg-yellow-100 text-yellow-800",
@@ -117,43 +118,6 @@ export default function DashboardPage() {
     .sort((a, b) => a.quantity - b.quantity)
     .slice(0, 5);
 
-  const barChartData = {
-    labels: ["Users", "Products", "Orders"],
-    datasets: [
-      {
-        label: "Count",
-        data: [users.length, products.length, orders.length],
-        backgroundColor: ["#3b82f6", "#10b981", "#8b5cf6"],
-        borderRadius: 6,
-      },
-    ],
-  };
-
-  const pieChartData = {
-    labels: ["Users", "Products", "Orders"],
-    datasets: [
-      {
-        data: [users.length, products.length, orders.length],
-        backgroundColor: ["#3b82f6", "#10b981", "#8b5cf6"],
-      },
-    ],
-  };
-
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: { legend: { display: false } },
-    scales: {
-      y: { beginAtZero: true, ticks: { precision: 0 } },
-    },
-  };
-
-  const pieOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: { legend: { position: "bottom" } },
-  };
-
   if (isLoading) {
     return (
       <div className="container py-6">
@@ -202,20 +166,11 @@ export default function DashboardPage() {
       </div>
 
       {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
-        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-          <h2 className="text-sm font-semibold text-gray-800 uppercase mb-4">Overview</h2>
-          <div className="h-72">
-            <Bar data={barChartData} options={chartOptions} />
-          </div>
-        </div>
-        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-          <h2 className="text-sm font-semibold text-gray-800 uppercase mb-4">Distribution</h2>
-          <div className="h-72">
-            <Pie data={pieChartData} options={pieOptions} />
-          </div>
-        </div>
-      </div>
+      <DashboardCharts
+        userCount={users.length}
+        productCount={products.length}
+        orderCount={orders.length}
+      />
 
       {/* Quick Actions */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 mb-8">

--- a/components/DashboardCharts.jsx
+++ b/components/DashboardCharts.jsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Bar, Pie } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
+
+const chartOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { display: false } },
+  scales: {
+    y: { beginAtZero: true, ticks: { precision: 0 } },
+  },
+};
+
+const pieOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { position: "bottom" } },
+};
+
+export default function DashboardCharts({ userCount, productCount, orderCount }) {
+  const labels = ["Users", "Products", "Orders"];
+  const counts = [userCount, productCount, orderCount];
+  const colors = ["#3b82f6", "#10b981", "#8b5cf6"];
+
+  const barChartData = {
+    labels,
+    datasets: [{ label: "Count", data: counts, backgroundColor: colors, borderRadius: 6 }],
+  };
+
+  const pieChartData = {
+    labels,
+    datasets: [{ data: counts, backgroundColor: colors }],
+  };
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h2 className="text-sm font-semibold text-gray-800 uppercase mb-4">Overview</h2>
+        <div className="h-72">
+          <Bar data={barChartData} options={chartOptions} />
+        </div>
+      </div>
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h2 className="text-sm font-semibold text-gray-800 uppercase mb-4">Distribution</h2>
+        <div className="h-72">
+          <Pie data={pieChartData} options={pieOptions} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Third batch - verified each finding against actual behavior before fixing. Pushed back on one that turned out to be intentional.

- **Cart quantity validation**: `POST /api/cart` accepted any numeric quantity including negative, which passed the stock check and corrupted the stored quantity via `$inc`. Now requires a positive integer.
- **Duplicate CSS import**: `react-toastify`'s CSS loaded twice (root layout + shop layout). Removed the redundant one.
- **Missing Suspense boundary**: `/search` used `useSearchParams()` without Suspense (required by Next.js, throws during static generation). Fixed. `/reset-password` was also flagged but already had one via its `page.js` wrapper - false positive on the audit's part.
- **chart.js eager-loaded** (~200KB+) on the admin dashboard page even before its own data renders. Extracted into `components/DashboardCharts.jsx`, lazy-loaded via `next/dynamic` with `ssr: false` (safe here - the page is already a Client Component).
- **Homepage below-fold sections** (Deals, Ads, Trending, Testimonials, FAQHome, NewsLetter) now split into separate chunks via `next/dynamic`. Note: no `ssr: false` here - the homepage is a Server Component, and Next only allows `ssr: false` from a Client Component (this exact rule broke the previous PR's build once already, see below, so staying conservative).

## Pushed back on
- Checkout page's `staleTime: 0` / forced refetch-on-mount - this is the payment flow; wanting the freshest price/stock data before charging a card is correct behavior, not a bug. Left unchanged.

## Deliberately not done here (flagged, not silently skipped)
Each of these is a real architectural change with meaningfully higher regression risk than what's above - the same class of change that broke the previous PR's build once already (a Server Component couldn't pass raw icon function props to a Client Component child):
- Missing `staleTime` on ~20 queries - blanket-adding it risks changing intended freshness per query without reviewing each individually.
- 3 pages doing client-side fetching that could be Server Components - real per-page refactors.
- 4 dynamic client-page routes not calling `notFound()` - they already show a graceful error state on a missing resource; a real HTTP 404 needs server-side data fetching first. All four are auth-gated, non-indexed pages, so lower priority.
- Broader Suspense adoption - a design choice, not a defined bug.
- ~300 lines of duplicated client-side PDF generation - real duplication, belongs server-side, but deserves its own deliberate pass rather than being folded in here.

## Test plan
- [x] All touched pages compile clean on the dev server
- [x] Homepage still server-renders below-fold section content (SSR unaffected by the `dynamic()` change)
- [x] Learned from the previous PR's build failure - this batch avoids `ssr: false` from any Server Component