### PR TITLE
fix: low-severity findings from audit

### DIFF
--- a/app/(shop)/about-us/AboutUs.jsx
+++ b/app/(shop)/about-us/AboutUs.jsx
@@ -1,6 +1,3 @@
-'use client';
-
-import React from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,4 +1,3 @@
-import localFont from "next/font/local";
 import { Poppins, Roboto } from "next/font/google";
 import "./globals.css";
 import ReactQueryProvider from "@/providers/ReactQueryProvider";
@@ -6,16 +5,6 @@ import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import ClientLayout from "./ClientLayout";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
 const poppins = Poppins({
   subsets: ["latin"],
   weight: ["400", "500", "600", "700"],
@@ -58,7 +47,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${poppins.variable} ${roboto.variable} antialiased`}
+        className={`${poppins.variable} ${roboto.variable} antialiased`}
       >
         <ReactQueryProvider>
           <ClientLayout>{children}</ClientLayout>

--- a/components/Banner.jsx
+++ b/components/Banner.jsx
@@ -1,13 +1,18 @@
 import React from "react";
 import Link from "next/link";
+import Image from "next/image";
 
 const Banner = () => {
   return (
-    <div
-      className="bg-cover bg-no-repeat bg-center py-16 md:py-36 px-4"
-      style={{ backgroundImage: "url('/images/banner-bg.jpg')" }}
-    >
-      <div className="container">
+    <div className="relative py-16 md:py-36 px-4">
+      <Image
+        src="/images/banner-bg.jpg"
+        alt=""
+        fill
+        priority
+        className="object-cover -z-10"
+      />
+      <div className="container relative z-10">
         <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl text-gray-800 font-medium mb-4 capitalize leading-tight">
           Best collection for <br /> home decoration
         </h1>

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import Link from "next/link";
 import { FaFacebook, FaInstagram, FaTwitter, FaPinterest } from "react-icons/fa";

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactStrictMode: true,
+  poweredByHeader: false,
   experimental: {
     optimizePackageImports: ["react-icons"],
   },
   images: {
+    formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
Final batch - 11 low-severity findings. Two turned out to be false positives on verification, caught before making unnecessary changes.

- **Footer.jsx / AboutUs.jsx**: had `'use client'` with zero hooks/state and no function props passed to client children (specifically checked for this - it's what broke a build earlier in this audit). Converted to Server Components.
- **Unused Geist fonts**: loaded but referenced by zero component. Removed.
- **next.config.mjs**: added `reactStrictMode`, `poweredByHeader: false`, `images.formats`. Deliberately skipped `output: "standalone"` - that's for self-hosted/Docker, can conflict with Vercel's own build pipeline (this app's actual deployment target).
- **Banner.jsx** (homepage hero, likely LCP element): raw CSS `background-image` -> `next/image` with `fill priority`, matching the pattern already used elsewhere in this codebase.

## Verified false positives
- `.env` vs `.env.local` - `.env` is already gitignored, never committed; secrets come from Vercel's dashboard, not a file, so the concern doesn't apply.
- "Homepage sections missing skeletons" - Trending, Deals, BestSellers, NewArrival, ShopByCategory all already have one. Checked each file directly.

## Deferred / pushed back on
- Client-side redirect-on-unauthenticated alongside middleware - not pure redundancy, it also catches a session expiring while already on the page (middleware only runs on navigation).
- Duplicate PDF generation code + 62 `console.error` calls - real but same category as the medium-severity PR's deferred item / mostly legitimate server-side logging, not worth a mechanical sweep.
- Full TypeScript migration - out of scope, agreed earlier in this session.

## Test plan
- [x] `/` and `/about-us` compile clean
- [x] Banner image and hero heading still render