### PR TITLE
fix: dashboard layouts as server components (#7) + popularity dedup (#11)

### DIFF
--- a/app/(shop)/products/[id]/ProductDetails.jsx
+++ b/app/(shop)/products/[id]/ProductDetails.jsx
@@ -276,11 +276,19 @@ const ProductDetails = ({ params, initialProduct }) => {
     setRating(value);
   };
 
-  // Increment popularity on page load
+  // Increment popularity once per product per browser session - without
+  // this guard a refresh or client-side re-nav to the same product fires
+  // another increment. sessionStorage keeps it to one view per tab session
+  // (the server also rate-limits per IP+product as a backstop).
   useEffect(() => {
+    if (!id) return;
+    const key = `pop_viewed_${id}`;
+    if (typeof window !== "undefined" && sessionStorage.getItem(key)) return;
+
     const increment = async () => {
       try {
         await incrementPopularity(id, 1);
+        if (typeof window !== "undefined") sessionStorage.setItem(key, "1");
       } catch (error) {
         console.error("Failed to increment popularity:", error);
       }

--- a/app/dashboard/layout.jsx
+++ b/app/dashboard/layout.jsx
@@ -1,20 +1,9 @@
-"use client";
-
 import DashboardSidebar from "@/components/DashboardSidebar";
-import { FiPlus, FiPackage, FiUsers, FiShoppingCart, FiGrid } from "react-icons/fi";
-
-const navItems = [
-  { href: "/dashboard", icon: FiGrid, label: "Overview" },
-  { href: "/dashboard/add-product", icon: FiPlus, label: "Add" },
-  { href: "/dashboard/products-list", icon: FiPackage, label: "Products" },
-  { href: "/dashboard/users", icon: FiUsers, label: "Users" },
-  { href: "/dashboard/orders", icon: FiShoppingCart, label: "Orders" },
-];
 
 export default function DashboardLayout({ children }) {
   return (
     <div className="flex h-screen">
-      <DashboardSidebar title="Admin" navItems={navItems} />
+      <DashboardSidebar title="Admin" variant="admin" />
       <main className="flex-1 overflow-y-auto bg-gray-50 pb-16 md:pb-0">
         {children}
       </main>

--- a/app/user-dashboard/layout.jsx
+++ b/app/user-dashboard/layout.jsx
@@ -1,20 +1,9 @@
-"use client";
-
 import DashboardSidebar from "@/components/DashboardSidebar";
-import { FiGrid, FiHeart, FiShoppingCart, FiPackage, FiUser } from "react-icons/fi";
-
-const navItems = [
-  { href: "/user-dashboard", icon: FiGrid, label: "Overview" },
-  { href: "/user-dashboard/wishlist", icon: FiHeart, label: "Wishlist" },
-  { href: "/user-dashboard/cart", icon: FiShoppingCart, label: "Cart" },
-  { href: "/user-dashboard/orders", icon: FiPackage, label: "Orders" },
-  { href: "/user-dashboard/profile", icon: FiUser, label: "Profile" },
-];
 
 export default function UserDashboardLayout({ children }) {
   return (
     <div className="flex h-screen">
-      <DashboardSidebar title="My Account" navItems={navItems} />
+      <DashboardSidebar title="My Account" variant="user" />
       <main className="flex-1 overflow-y-auto bg-gray-50 pb-16 md:pb-0">
         {children}
       </main>

--- a/components/DashboardSidebar.jsx
+++ b/components/DashboardSidebar.jsx
@@ -3,14 +3,45 @@
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
-import { FiHome } from "react-icons/fi";
+import {
+  FiHome,
+  FiGrid,
+  FiPlus,
+  FiPackage,
+  FiUsers,
+  FiShoppingCart,
+  FiHeart,
+  FiUser,
+} from "react-icons/fi";
 import SignOut from "./SignOut";
 
-export default function DashboardSidebar({ title, navItems }) {
+// Nav definitions live here (a Client Component) rather than being passed
+// down as props: the icons are function references, which a Server
+// Component parent (the layout) cannot serialize to send across the
+// server/client boundary. Keeping them here lets the layouts stay Server
+// Components and pass only a plain string variant.
+const NAV_ITEMS = {
+  admin: [
+    { href: "/dashboard", icon: FiGrid, label: "Overview" },
+    { href: "/dashboard/add-product", icon: FiPlus, label: "Add" },
+    { href: "/dashboard/products-list", icon: FiPackage, label: "Products" },
+    { href: "/dashboard/users", icon: FiUsers, label: "Users" },
+    { href: "/dashboard/orders", icon: FiShoppingCart, label: "Orders" },
+  ],
+  user: [
+    { href: "/user-dashboard", icon: FiGrid, label: "Overview" },
+    { href: "/user-dashboard/wishlist", icon: FiHeart, label: "Wishlist" },
+    { href: "/user-dashboard/cart", icon: FiShoppingCart, label: "Cart" },
+    { href: "/user-dashboard/orders", icon: FiPackage, label: "Orders" },
+    { href: "/user-dashboard/profile", icon: FiUser, label: "Profile" },
+  ],
+};
+
+export default function DashboardSidebar({ title, variant }) {
   const pathname = usePathname();
 
   const items = [
-    ...navItems,
+    ...(NAV_ITEMS[variant] || []),
     { href: "/", icon: FiHome, label: "Home" },
   ];
 


### PR DESCRIPTION
## Summary
Two quick-fix items from the audit follow-up.

### #7 - dashboard layouts as Server Components
Retry of a fix that broke the build once, done properly. The earlier attempt passed `navItems` with raw icon function references to `DashboardSidebar`; a Server Component can't serialize functions across the boundary. Moved the nav definitions into `DashboardSidebar` (already a Client Component), keyed by a plain string `variant`. Layouts now pass only strings → convert to Server Components cleanly.

### #11 - popularity increment dedup
The increment `useEffect` fired on every mount, so a refresh or client-side re-nav to the same product kept inflating its score. Added a `sessionStorage` guard (once per product per tab session). Server-side per-IP+product rate limit remains as a backstop.

## Test plan
- [x] Dashboard pages + PDP compile clean on dev server
- [ ] **Vercel production build is the real gate for #7** (dev passed last time too; the production build is what caught the boundary error) - watching before merge