### PR TITLE
refactor: profile pages as server components (#23)

### DIFF
--- a/actions/user-utils/index.js
+++ b/actions/user-utils/index.js
@@ -16,20 +16,3 @@ export const getUsers = async () => {
     throw error;
   }
 }
-
-//get user by id
-export const getUserById = async (id) => {
-  try {
-    const response = await api.get(`/users/${id}`, {
-      headers: {
-        'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '0'
-      },
-    });
-    return response.data;
-  } catch (error) {
-    console.error("Error fetching user:", error);
-    throw error;
-  }
-}

--- a/app/(shop)/profile/[id]/page.js
+++ b/app/(shop)/profile/[id]/page.js
@@ -1,120 +1,22 @@
-"use client";
 import Image from "next/image";
 import Link from "next/link";
-import { notFound, useRouter } from "next/navigation";
-import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { notFound, redirect } from "next/navigation";
 import { FaUser, FaShoppingCart, FaHeart, FaBox } from "react-icons/fa";
-import { getUserById } from "@/actions/user-utils";
+import { getUserForViewer } from "@/lib/get-user";
 
-const SkeletonProfile = () => (
-  <div className="w-full p-6 animate-pulse">
-    <div className="bg-white shadow-lg rounded-lg overflow-hidden">
-      <div className="bg-gradient-to-r from-blue-500 to-indigo-600 p-8">
-        <div className="flex items-center space-x-8">
-          <div className="w-32 h-32 rounded-full bg-gray-300 border-4 border-white"></div>
-          <div className="space-y-3">
-            <div className="h-8 w-64 bg-gray-300 rounded"></div>
-            <div className="h-6 w-80 bg-gray-300 rounded"></div>
-          </div>
-        </div>
-      </div>
-      <div className="p-8">
-        <div className="mb-8">
-          <div className="h-8 w-56 bg-gray-200 rounded mb-3"></div>
-          <div className="bg-gray-50 p-6 rounded-lg">
-            <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-40 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-64 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-48 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-40 bg-gray-200 rounded"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="h-8 w-56 bg-gray-200 rounded mb-4"></div>
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {Array(4)
-            .fill()
-            .map((_, index) => (
-              <div
-                key={index}
-                className="bg-white border border-gray-200 rounded-lg p-6 h-40 flex flex-col items-center justify-center"
-              >
-                <div className="w-12 h-12 bg-gray-200 rounded-full mb-3"></div>
-                <div className="h-5 w-32 bg-gray-200 rounded mb-2"></div>
-                <div className="h-4 w-40 bg-gray-200 rounded"></div>
-              </div>
-            ))}
-        </div>
-      </div>
-      <div className="bg-gray-50 p-8 border-t border-gray-200">
-        <div className="flex justify-between items-center">
-          <div className="h-5 w-56 bg-gray-200 rounded"></div>
-          <div className="h-10 w-24 bg-gray-200 rounded-md"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-export default function UserProfile({ params }) {
+export default async function UserProfile({ params }) {
   const id = params?.id;
-  const router = useRouter();
+  const result = await getUserForViewer(id);
 
-  const { data, error, isLoading } = useQuery({
-    queryKey: ["user", id],
-    queryFn: () => getUserById(id),
-    refetchOnWindowFocus: false,
-    retry: false,
-    enabled: !!id,
-  });
-
-  useEffect(() => {
-    if (error) {
-      if (error.message.includes("Unauthorized")) {
-        toast.error("Please log in to view this profile.", {
-          position: "top-right",
-          autoClose: 3000,
-        });
-        router.push("/login");
-      } else {
-        toast.error(`Error loading profile: ${error.message}`, {
-          position: "top-right",
-          autoClose: 3000,
-        });
-      }
-    }
-  }, [error, router]);
-
-  const user = data?.user || {};
-
-  const hasProfileImage = !!user.image;
-
-  // A missing/invalid user is a 404, not an error screen
-  if (
-    error &&
-    (error.message.includes("User not found") ||
-      error.message.includes("Invalid user ID format"))
-  ) {
+  if (result.status === "unauthorized") {
+    redirect("/login");
+  }
+  if (result.status === "notfound") {
     notFound();
   }
 
-  if (isLoading) {
-    return <SkeletonProfile />;
-  }
+  const user = result.user;
+  const hasProfileImage = !!user.image;
 
   return (
     <div className="w-full min-h-screen bg-gray-100 p-6">

--- a/app/(shop)/users/[id]/page.js
+++ b/app/(shop)/users/[id]/page.js
@@ -1,109 +1,21 @@
-"use client";
 import Image from "next/image";
 import Link from "next/link";
-import { notFound, useRouter } from "next/navigation";
-import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { notFound, redirect } from "next/navigation";
 import { FaUser } from "react-icons/fa";
-import { getUserById } from "@/actions/user-utils";
+import { getUserForViewer } from "@/lib/get-user";
 
-// Skeleton Loader Component
-const SkeletonProfile = () => (
-  <div className="max-w-3xl mx-auto p-6 animate-pulse">
-    <div className="bg-white shadow-lg rounded-lg overflow-hidden">
-      {/* Profile Header Skeleton */}
-      <div className="bg-gradient-to-r from-blue-500 to-indigo-600 p-6">
-        <div className="flex items-center space-x-6">
-          <div className="w-24 h-24 rounded-full bg-gray-300 border-4 border-white"></div>
-          <div className="space-y-2">
-            <div className="h-6 w-40 bg-gray-300 rounded"></div>
-            <div className="h-4 w-60 bg-gray-300 rounded"></div>
-          </div>
-        </div>
-      </div>
-      {/* Profile Content Skeleton */}
-      <div className="p-6">
-        <div className="mb-6">
-          <div className="h-6 w-40 bg-gray-200 rounded mb-2"></div>
-          <div className="bg-gray-50 p-4 rounded-md">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <div className="h-4 w-20 bg-gray-200 rounded mb-1"></div>
-                <div className="h-4 w-32 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-4 w-20 bg-gray-200 rounded mb-1"></div>
-                <div className="h-4 w-48 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-4 w-20 bg-gray-200 rounded mb-1"></div>
-                <div className="h-4 w-40 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-4 w-20 bg-gray-200 rounded mb-1"></div>
-                <div className="h-4 w-32 bg-gray-200 rounded"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      {/* Profile Footer Skeleton */}
-      <div className="bg-gray-50 p-6 border-t border-gray-200">
-        <div className="flex justify-between items-center">
-          <div className="h-4 w-40 bg-gray-200 rounded"></div>
-          <div className="h-8 w-20 bg-gray-200 rounded-md"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-export default function UserProfile({ params }) {
+export default async function UserProfile({ params }) {
   const { id } = params;
-  const router = useRouter();
+  const result = await getUserForViewer(id);
 
-  const { data, error, isLoading } = useQuery({
-    queryKey: ["user", id],
-    queryFn: () => getUserById(id),
-    refetchOnWindowFocus: false,
-    retry: false,
-    enabled: !!id,
-  });
-
-  // Handle errors
-  useEffect(() => {
-    if (error) {
-      if (error.message.includes("Unauthorized")) {
-        toast.error("Please log in to view this profile.", {
-          position: "top-right",
-          autoClose: 3000,
-        });
-        router.push("/login");
-      } else {
-        toast.error(`Error loading profile: ${error.message}`, {
-          position: "top-right",
-          autoClose: 3000,
-        });
-      }
-    }
-  }, [error, router]);
-
-  // A missing/invalid user is a 404, not an error screen
-  if (
-    error &&
-    (error.message.includes("User not found") ||
-      error.message.includes("Invalid user ID format"))
-  ) {
+  if (result.status === "unauthorized") {
+    redirect("/login");
+  }
+  if (result.status === "notfound") {
     notFound();
   }
 
-  if (isLoading) {
-    return <SkeletonProfile />;
-  }
-
-  const user = data?.user || {};
-
+  const user = result.user;
   const hasProfileImage = !!user.image;
 
   return (
@@ -113,7 +25,7 @@ export default function UserProfile({ params }) {
           <div className="flex items-center space-x-6">
             <div className="relative w-24 h-24 rounded-full overflow-hidden bg-gray-100 border-4 border-white">
               {hasProfileImage ? (
-                <Image 
+                <Image
                   src={user.image}
                   alt={user.name || "Profile picture"}
                   fill
@@ -132,7 +44,7 @@ export default function UserProfile({ params }) {
             </div>
           </div>
         </div>
-        
+
         <div className="p-6">
           <div className="mb-6">
             <h2 className="text-xl font-semibold text-gray-800 mb-2">Account Details</h2>
@@ -158,14 +70,14 @@ export default function UserProfile({ params }) {
             </div>
           </div>
         </div>
-        
+
         <div className="bg-gray-50 p-6 border-t border-gray-200">
           <div className="flex justify-between items-center">
             <p className="text-sm text-gray-500">
               Account Created: {user.createdAt ? new Date(user.createdAt).toLocaleString() : "N/A"}
             </p>
-            <Link 
-              href="/api/auth/signout" 
+            <Link
+              href="/api/auth/signout"
               className="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded-md text-gray-700 text-sm font-medium transition-colors duration-200"
             >
               Sign Out

--- a/app/user-dashboard/profile/page.js
+++ b/app/user-dashboard/profile/page.js
@@ -1,121 +1,26 @@
-"use client";
 import Image from "next/image";
 import Link from "next/link";
-import { notFound, useRouter } from "next/navigation";
-import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { toast } from "react-toastify";
+import { notFound, redirect } from "next/navigation";
 import { FaUser, FaShoppingCart, FaHeart, FaBox } from "react-icons/fa";
-import { getUserById } from "@/actions/user-utils";
-import { useSession } from "next-auth/react";
+import { session } from "@/actions/auth-utils";
+import { getUserForViewer } from "@/lib/get-user";
 
-const SkeletonProfile = () => (
-  <div className="w-full p-6 animate-pulse">
-    <div className="bg-white shadow-lg rounded-lg overflow-hidden">
-      <div className="bg-primary p-8">
-        <div className="flex items-center space-x-8">
-          <div className="w-32 h-32 rounded-full bg-gray-300 border-4 border-white"></div>
-          <div className="space-y-3">
-            <div className="h-8 w-64 bg-gray-300 rounded"></div>
-            <div className="h-6 w-80 bg-gray-300 rounded"></div>
-          </div>
-        </div>
-      </div>
-      <div className="p-8">
-        <div className="mb-8">
-          <div className="h-8 w-56 bg-gray-200 rounded mb-3"></div>
-          <div className="bg-gray-50 p-6 rounded-lg">
-            <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-40 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-64 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-48 bg-gray-200 rounded"></div>
-              </div>
-              <div>
-                <div className="h-5 w-24 bg-gray-200 rounded mb-2"></div>
-                <div className="h-5 w-40 bg-gray-200 rounded"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div className="h-8 w-56 bg-gray-200 rounded mb-4"></div>
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
-          {Array(4)
-            .fill()
-            .map((_, index) => (
-              <div
-                key={index}
-                className="bg-white border border-gray-200 rounded-lg p-6 h-40 flex flex-col items-center justify-center"
-              >
-                <div className="w-12 h-12 bg-gray-200 rounded-full mb-3"></div>
-                <div className="h-5 w-32 bg-gray-200 rounded mb-2"></div>
-                <div className="h-4 w-40 bg-gray-200 rounded"></div>
-              </div>
-            ))}
-        </div>
-      </div>
-      <div className="bg-gray-50 p-8 border-t border-gray-200">
-        <div className="flex justify-between items-center">
-          <div className="h-5 w-56 bg-gray-200 rounded"></div>
-          <div className="h-10 w-24 bg-gray-200 rounded-md"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-);
+export default async function UserProfile() {
+  const userSession = await session();
+  if (!userSession?.user) {
+    redirect("/login");
+  }
 
-export default function UserProfile() {
-  const { data: userSession, status } = useSession();
-  const router = useRouter();
-
-  const { data, error, isLoading } = useQuery({
-    queryKey: ["user", userSession?.user?.id],
-    queryFn: () => getUserById(userSession?.user?.id),
-    refetchOnWindowFocus: false,
-    retry: false,
-    enabled: !!userSession?.user?.id,
-  });
-
-  useEffect(() => {
-    if (error) {
-      if (error.message.includes("Unauthorized")) {
-        toast.error("Please log in to view this profile.", {
-          position: "top-right",
-          autoClose: 3000,
-        });
-        router.push("/login");
-      } else {
-        toast.error(`Error loading profile: ${error.message}`, {
-          position: "top-right",
-          autoClose: 3000,
-        });
-      }
-    }
-  }, [error, router]);
-
-  const user = data?.user || {};
-
-  const hasProfileImage = !!user.image;
-
-  // A missing/invalid user is a 404, not an error screen
-  if (
-    error &&
-    (error.message.includes("User not found") ||
-      error.message.includes("Invalid user ID format"))
-  ) {
+  const result = await getUserForViewer(userSession.user.id);
+  if (result.status === "unauthorized") {
+    redirect("/login");
+  }
+  if (result.status === "notfound") {
     notFound();
   }
 
-  if (isLoading) {
-    return <SkeletonProfile />;
-  }
+  const user = result.user;
+  const hasProfileImage = !!user.image;
 
   return (
     <div className="w-full min-h-screen bg-gray-100 p-6 mb-12 sm:mb-0">

--- a/lib/get-user.js
+++ b/lib/get-user.js
@@ -1,0 +1,47 @@
+import { session } from "@/actions/auth-utils";
+import { dbConnect } from "@/service/mongo";
+import { User } from "@/models/user-model";
+
+// Server-side user fetch with the same authorization as GET /api/users/[id]:
+// must be logged in, and may only view own profile unless admin. Returns
+// one of: { status: "unauthorized" } (redirect to login),
+// { status: "notfound" } (404), or { status: "ok", user }.
+export async function getUserForViewer(id) {
+  const userSession = await session();
+  if (!userSession?.user) {
+    return { status: "unauthorized" };
+  }
+
+  if (userSession.user.role !== "admin" && userSession.user.id !== id) {
+    return { status: "unauthorized" };
+  }
+
+  await dbConnect();
+
+  let user;
+  try {
+    user = await User.findById(id).select("-password").lean();
+  } catch (error) {
+    if (error.name === "CastError" && error.kind === "ObjectId") {
+      return { status: "notfound" };
+    }
+    throw error;
+  }
+
+  if (!user) {
+    return { status: "notfound" };
+  }
+
+  // Plain-object-ify for safe rendering (ObjectId/Date -> string primitives).
+  return {
+    status: "ok",
+    user: {
+      _id: user._id.toString(),
+      name: user.name ?? null,
+      email: user.email ?? null,
+      image: user.image ?? null,
+      role: user.role ?? null,
+      createdAt: user.createdAt ? user.createdAt.toISOString() : null,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
The three profile pages were Client Components fetching user data via `useQuery` → `/api/users/[id]` → DB - a client round-trip for pure read-only display (no forms, only navigation `<Link>`s). Converted all three to async Server Components fetching directly.

- **`lib/get-user.js`**: server-side fetch replicating the exact authorization of `GET /api/users/[id]` (logged in; own profile only unless admin). Returns a typed status so the page can `redirect()` (unauthorized) or `notFound()` (missing/invalid id), and serializes ObjectId/Date to strings for safe rendering.
- `app/(shop)/users/[id]`, `app/(shop)/profile/[id]`, `app/user-dashboard/profile` now render complete HTML on first response - removed the three dead `SkeletonProfile` blocks (server components don't need a client loading state).
- Removed the now-unused `getUserById` client action.

## Security check
- [x] Unauthenticated request to `/users/[id]` serves login content, **not** the profile's Account Details - verified no data bypass (this route isn't in the middleware matcher, so the page's own `redirect()` is what protects it).
- [x] `/profile/[id]` and `/user-dashboard/profile` 302 to `/login` via existing middleware coverage.

## Test plan
- [x] All three pages + `/`, `/products` compile clean
- [ ] Vercel production build gate
- [ ] Post-merge: view own profile logged-in, confirm data renders; try viewing another user's `/users/[id]` as non-admin, confirm redirect