### PR TITLE
feat: show/hide password toggle on login and register

### DIFF
--- a/app/(auth)/login/LoginForm.jsx
+++ b/app/(auth)/login/LoginForm.jsx
@@ -6,11 +6,13 @@ import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { getCallbackUrl } from "@/lib/callback-url";
 import { toast } from "react-toastify";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { login } from "@/actions/auth-utils";
 
 const LoginPage = () => {
   const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -162,14 +164,24 @@ const LoginPage = () => {
               <label htmlFor="password" className="text-gray-600 mb-2 block">
                 Password
               </label>
-              <input
-                type="password"
-                name="password"
-                id="password"
-                className="block w-full border border-gray-300 px-4 py-3 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
-                placeholder="*******"
-                required
-              />
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  name="password"
+                  id="password"
+                  className="block w-full border border-gray-300 px-4 py-3 pr-11 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
+                  placeholder="*******"
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((s) => !s)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <FaEyeSlash /> : <FaEye />}
+                </button>
+              </div>
             </div>
           </div>
 

--- a/app/(auth)/register/RegisterForm.jsx
+++ b/app/(auth)/register/RegisterForm.jsx
@@ -7,6 +7,7 @@ import React, { useState } from "react";
 import { useRouter } from "next/navigation";
 import { getCallbackUrl } from "@/lib/callback-url";
 import { toast } from "react-toastify";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { registerUser } from "@/actions/register";
 
 const RegisterPage = () => {
@@ -21,6 +22,7 @@ const RegisterPage = () => {
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState(null);
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
@@ -204,31 +206,51 @@ const RegisterPage = () => {
               <label htmlFor="password" className="text-gray-600 mb-2 block">
                 Password
               </label>
-              <input
-                type="password"
-                name="password"
-                id="password"
-                value={formData.password}
-                onChange={handleChange}
-                className="block w-full border border-gray-300 px-4 py-3 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
-                placeholder="*******"
-                required
-              />
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  name="password"
+                  id="password"
+                  value={formData.password}
+                  onChange={handleChange}
+                  className="block w-full border border-gray-300 px-4 py-3 pr-11 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
+                  placeholder="*******"
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((s) => !s)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <FaEyeSlash /> : <FaEye />}
+                </button>
+              </div>
             </div>
             <div>
               <label htmlFor="confirmPassword" className="text-gray-600 mb-2 block">
                 Confirm Password
               </label>
-              <input
-                type="password"
-                name="confirmPassword"
-                id="confirmPassword"
-                value={formData.confirmPassword}
-                onChange={handleChange}
-                className="block w-full border border-gray-300 px-4 py-3 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
-                placeholder="*******"
-                required
-              />
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  name="confirmPassword"
+                  id="confirmPassword"
+                  value={formData.confirmPassword}
+                  onChange={handleChange}
+                  className="block w-full border border-gray-300 px-4 py-3 pr-11 text-gray-600 text-sm rounded focus:ring-0 focus:border-primary placeholder-gray-400"
+                  placeholder="*******"
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((s) => !s)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-400 hover:text-gray-600"
+                >
+                  {showPassword ? <FaEyeSlash /> : <FaEye />}
+                </button>
+              </div>
             </div>
           </div>
           <div className="mt-6">


### PR DESCRIPTION
## What

Adds a show/hide password toggle to the login and register forms.

- Eye-icon button (`react-icons` FaEye/FaEyeSlash) toggles password field between `password` and `text`.
- Login: single password field.
- Register: one toggle controls both the password and confirm-password fields (reveal together).
- Button is `type="button"` (no form submit), has `aria-label`, input padded with `pr-11` so text doesn't overlap the icon.

## Test

Manual: click the eye on each field, password text reveals/hides.

https://claude.ai/code/session_01Rheh5pVZgtiuNDUJQgkwiq