### PR TITLE
feat: clear-cart option + single toast for wishlist Add All to Cart

### DIFF
--- a/actions/cart-utils/index.js
+++ b/actions/cart-utils/index.js
@@ -52,6 +52,23 @@ export const removeFromCart = async (productId) => {
   }
 };
 
+// Clear the entire cart in a single request
+export const clearCart = async () => {
+  try {
+    const result = await api.delete('/cart', {
+      data: { clearAll: true },
+      headers: {
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        Pragma: "no-cache",
+        Expires: "0",
+      },
+    });
+    return result.data;
+  } catch (error) {
+    throw new Error(error.response?.data?.error || error.message);
+  }
+};
+
 // Update product quantity in cart
 export const updateCartQuantity = async (productId, quantity) => {
   try {

--- a/app/(shop)/cart/page.js
+++ b/app/(shop)/cart/page.js
@@ -14,10 +14,11 @@ import {
   FaPlus, 
   FaMinus 
 } from "react-icons/fa";
-import { getCart, removeFromCart, updateCartQuantity } from "@/actions/cart-utils";
+import { getCart, removeFromCart, updateCartQuantity, clearCart } from "@/actions/cart-utils";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import LoadError from "@/components/LoadError";
+import { useConfirm } from "@/hooks/useConfirm";
 
 // Skeleton Loader for Cart Items
 const SkeletonCartItem = () => (
@@ -40,6 +41,7 @@ const CartPage = () => {
   const user = userSession?.user;
 
   const router = useRouter();
+  const [confirm, ConfirmationDialog] = useConfirm();
 
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -113,6 +115,55 @@ const CartPage = () => {
       }
     },
   });
+
+  // Mutation to clear the whole cart in one request
+  const clearCartMutation = useMutation({
+    mutationFn: clearCart,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(["cart"]);
+      toast.success(data.message, {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    },
+    onError: (error) => {
+      if (error.message.includes("Unauthorized")) {
+        toast.error("Please log in to manage your cart.", {
+          position: "top-right",
+          autoClose: 3000,
+        });
+        setTimeout(() => {
+          router.push("/login");
+        }, 3000);
+      } else {
+        toast.error(`Error: ${error.message}`, {
+          position: "top-right",
+          autoClose: 3000,
+        });
+      }
+    },
+  });
+
+  const handleClearCart = async () => {
+    if (!user) {
+      toast.error("Please log in to manage your cart.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      setTimeout(() => {
+        router.push("/login");
+      }, 3000);
+      return;
+    }
+    const ok = await confirm({
+      title: "Clear cart?",
+      message: "Remove all items from your cart? This can't be undone.",
+      confirmText: "Clear Cart",
+    });
+    if (!ok) return;
+    if (clearCartMutation.isPending) return;
+    clearCartMutation.mutate();
+  };
 
   // Handle remove from cart
   const handleRemoveFromCart = (productId, e) => {
@@ -281,6 +332,7 @@ const CartPage = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-100 via-blue-50 to-teal-50 py-8 px-4">
+      <ConfirmationDialog />
       {/* Main Content */}
       <div className="max-w-6xl mx-auto">
         {/* Cart Summary Card */}
@@ -292,6 +344,24 @@ const CartPage = () => {
               <p className="text-gray-600">{totalItems} {totalItems === 1 ? "item" : "items"}</p>
             </div>
           </div>
+          {cart.items.length > 0 && (
+            <button
+              onClick={handleClearCart}
+              disabled={clearCartMutation.isPending}
+              className={`flex items-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md ${
+                clearCartMutation.isPending
+                  ? "bg-gray-400 cursor-not-allowed"
+                  : "bg-red-600 hover:bg-red-700 hover:shadow-lg"
+              }`}
+            >
+              {clearCartMutation.isPending ? (
+                <FaSpinner className="animate-spin" />
+              ) : (
+                <FaTrash />
+              )}
+              <span>Clear Cart</span>
+            </button>
+          )}
         </div>
 
         {/* Cart Items or Empty State */}

--- a/app/(shop)/wishlist/page.js
+++ b/app/(shop)/wishlist/page.js
@@ -43,6 +43,7 @@ const Wishlist = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 12;
   const [confirm, ConfirmationDialog] = useConfirm();
+  const [isAddingAll, setIsAddingAll] = useState(false);
 
   useEffect(() => {
     if (status === "unauthenticated") {
@@ -159,6 +160,46 @@ const Wishlist = () => {
         (item) => item.product._id.toString() === productId
       ) || false
     );
+  };
+
+  // Add every eligible wishlist item to the cart, then show a single toast
+  const handleAddAllToCart = async () => {
+    if (!user) {
+      toast.error("Please log in to add to cart.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      setTimeout(() => {
+        router.push("/login");
+      }, 3000);
+      return;
+    }
+    const toAdd = wishlist.filter(
+      (product) => !isInCart(product._id) && product.availability === "In Stock"
+    );
+    if (toAdd.length === 0) {
+      toast.info("All in-stock items are already in your cart.", {
+        position: "top-right",
+        autoClose: 3000,
+      });
+      return;
+    }
+    setIsAddingAll(true);
+    try {
+      await Promise.all(toAdd.map((product) => addToCart(product._id, 1)));
+      queryClient.invalidateQueries(["cart"]);
+      toast.success(
+        `${toAdd.length} item${toAdd.length > 1 ? "s" : ""} added to cart!`,
+        { position: "top-right", autoClose: 3000 }
+      );
+    } catch (error) {
+      toast.error(`Error: ${error.message}`, {
+        position: "top-right",
+        autoClose: 3000,
+      });
+    } finally {
+      setIsAddingAll(false);
+    }
   };
 
   // Handle removing an item from the wishlist
@@ -294,27 +335,19 @@ const Wishlist = () => {
           {wishlist.length > 0 && (
             <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
               <button
-                onClick={() => {
-                  wishlist.forEach((product) => {
-                    if (
-                      !isInCart(product._id) &&
-                      product.availability === "In Stock"
-                    ) {
-                      cartMutation.mutate({
-                        productId: product._id,
-                        quantity: 1,
-                      });
-                    }
-                  });
-                }}
-                disabled={cartMutation.isPending}
+                onClick={handleAddAllToCart}
+                disabled={isAddingAll}
                 className={`flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-semibold text-white transition-all duration-300 shadow-md w-full sm:w-auto ${
-                  cartMutation.isPending
+                  isAddingAll
                     ? "bg-gray-400 cursor-not-allowed"
                     : "bg-blue-600 hover:bg-blue-700 hover:shadow-lg"
                 }`}
               >
-                <FaShoppingCart />
+                {isAddingAll ? (
+                  <FaSpinner className="animate-spin" />
+                ) : (
+                  <FaShoppingCart />
+                )}
                 <span>Add All to Cart</span>
               </button>
               <button

--- a/app/api/cart/route.js
+++ b/app/api/cart/route.js
@@ -117,11 +117,20 @@ export async function DELETE(request) {
 
     await dbConnect();
 
-    const { productId } = await request.json();
+    const { productId, clearAll } = await request.json();
 
     const cart = await Cart.findOne({ user: userSession.user.id });
     if (!cart) {
       return NextResponse.json({ error: "Cart not found" }, { status: 404 });
+    }
+
+    if (clearAll) {
+      cart.items = [];
+      await cart.save();
+      return NextResponse.json(
+        { message: "Cart cleared successfully!", cart },
+        { status: 200 }
+      );
     }
 
     // Remove the item from the cart


### PR DESCRIPTION
## What

Two changes:

### 1. Clear Cart (new)
- "Clear Cart" button on the cart page summary card, shown when the cart is non-empty.
- Confirms via the existing `useConfirm` dialog, then empties the whole cart in one request.
- API `DELETE /cart` now handles a `clearAll` flag; new `clearCart` action mirrors `clearWishlist`.

### 2. Fix: multiple toasts on wishlist "Add All to Cart"
- Previously the button looped and called the cart mutation per item, firing one "Product added" toast per product (see screenshot in issue).
- Now adds all eligible (in-stock, not-already-in-cart) items via `Promise.all` and shows a single summary toast: "N items added to cart!". Invalidates the cart query once. Info toast if nothing eligible.

## Test

Manual:
- Cart page → Clear Cart → confirm → cart empties, single toast.
- Wishlist → Add All to Cart → one toast regardless of item count.

https://claude.ai/code/session_01Rheh5pVZgtiuNDUJQgkwiq