### PR TITLE
fix: stop MongoDB connection leak (Atlas max-connections alert)

### DIFF
--- a/service/mongo.js
+++ b/service/mongo.js
@@ -13,7 +13,11 @@ export async function dbConnect() {
     }
 
     if (!cached.promise) {
-        cached.promise = mongoose.connect(String(MONGODB_URI)).then((m) => m);
+        // maxPoolSize caps the mongoose pool (driver default is 100) so it and
+        // the native adapter client don't together exhaust Atlas's connection limit.
+        cached.promise = mongoose
+            .connect(String(MONGODB_URI), { maxPoolSize: 10 })
+            .then((m) => m);
     }
 
     try {

--- a/service/mongoClientPromise.js
+++ b/service/mongoClientPromise.js
@@ -9,12 +9,17 @@ if (!process.env.MONGODB_CONNECTION_STRING) {
 }
 
 const uri = process.env.MONGODB_CONNECTION_STRING;
-const options = {};
+// Cap the pool so serverless instances don't each open the driver default of
+// 100 connections and exhaust Atlas's shared-tier connection limit.
+const options = { maxPoolSize: 10 };
 
 let client;
 let mongoClientPromise;
 
-if (process.env.ENVIRONMENT === 'development') {
+// NODE_ENV, not ENVIRONMENT (which was never set) - the wrong check sent dev
+// down the else branch, opening a fresh client on every HMR reload and leaking
+// pools until Atlas neared its max-connections cap.
+if (process.env.NODE_ENV === 'development') {
     // In development mode, use a global variable so that the value
     // is preserved across module reloads caused by HMR (Hot Module Replacement).
     if (!global._mongomongoClientPromise) {


### PR DESCRIPTION
## Why the alert fires
Atlas showed "nearing maximum connections" — live count was **195/500** when investigated.

Two causes:

1. **Dev HMR leak** — `mongoClientPromise.js` gated the dev singleton on `process.env.ENVIRONMENT === 'development'`, but that var is never set. Next.js uses `NODE_ENV`, so dev fell through to the production branch and opened a **new `MongoClient` on every hot reload**, never releasing the old pool. A long editing session climbs toward the cap.
2. **Two oversized pools** — `dbConnect` (mongoose) and `mongoClientPromise` (native driver, for the NextAuth adapter) both used the driver default `maxPoolSize: 100`, so one instance can hold ~200 connections; serverless instances multiply that against the shared-tier limit.

## Fix
- Use `NODE_ENV` for the dev-singleton check → no more per-reload leak.
- Cap both pools at `maxPoolSize: 10`.

## Note
The currently-running dev server keeps its existing connections until restarted; production sheds them on next deploy.

## Test
- Products page (mongoose path) loads, 0 console errors.
- Lint clean on both service modules.

https://claude.ai/code/session_01Rheh5pVZgtiuNDUJQgkwiq