### PR TITLE
fix(auth): refresh session before redirect

### DIFF
--- a/app/(auth)/login/LoginForm.jsx
+++ b/app/(auth)/login/LoginForm.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-unescaped-entities */
 "use client";
-import { signIn } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 import Link from "next/link";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
@@ -8,9 +8,11 @@ import { getCallbackUrl } from "@/lib/callback-url";
 import { toast } from "react-toastify";
 import { FaEye, FaEyeSlash } from "react-icons/fa";
 import { login } from "@/actions/auth-utils";
+import { refreshSessionAndNavigate } from "@/lib/login-session";
 
 const LoginPage = () => {
   const router = useRouter();
+  const { update } = useSession();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -32,10 +34,11 @@ const LoginPage = () => {
           draggable: true,
           progress: undefined,
         });
-        setTimeout(() => {
-          router.push(getCallbackUrl());
-          router.refresh();
-        }, 2000);
+        await refreshSessionAndNavigate({
+          update,
+          router,
+          target: getCallbackUrl(),
+        });
       } 
     } catch (error) {
       console.error("Unexpected error during login:", error);

--- a/lib/login-session.js
+++ b/lib/login-session.js
@@ -1,0 +1,5 @@
+export async function refreshSessionAndNavigate({ update, router, target }) {
+  await update();
+  router.push(target);
+  router.refresh();
+}

--- a/lib/login-session.test.js
+++ b/lib/login-session.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { refreshSessionAndNavigate } from "./login-session";
+
+describe("refreshSessionAndNavigate", () => {
+  it("refreshes the client session before navigating", async () => {
+    const calls = [];
+    const update = vi.fn(async () => calls.push("update"));
+    const router = {
+      push: vi.fn(() => calls.push("push")),
+      refresh: vi.fn(() => calls.push("refresh")),
+    };
+
+    await refreshSessionAndNavigate({ update, router, target: "/dashboard" });
+
+    expect(calls).toEqual(["update", "push", "refresh"]);
+    expect(router.push).toHaveBeenCalledWith("/dashboard");
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the client SessionProvider after credentials login
- navigate only after the refreshed session is available
- add regression coverage for refresh-before-navigation ordering

## Verification
- npm test (19 passed)
- npm run build