### PR TITLE
fix(ui): fill homepage first viewport

### DIFF
--- a/components/Banner.jsx
+++ b/components/Banner.jsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 const Banner = () => {
   return (
-    <div className="relative py-16 md:py-36 px-4">
+    <section className="relative px-4 py-16 md:flex md:min-h-[calc(100dvh-9rem)] md:items-center md:py-12">
       <Image
         src="/images/banner-bg.jpg"
         alt=""
@@ -28,7 +28,7 @@ const Banner = () => {
           </Link>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- make the hero fill the viewport space remaining below header and navbar at md+
- vertically center hero content at larger breakpoints
- preserve the existing content-driven mobile layout

## Verification
- npm test (19 passed)
- npm run build